### PR TITLE
FIX: race condition on reorgs

### DIFF
--- a/ZcashLightClientKit/Block/Processor/CompactBlockDownloadOperation.swift
+++ b/ZcashLightClientKit/Block/Processor/CompactBlockDownloadOperation.swift
@@ -11,7 +11,7 @@ import Foundation
 class CompactBlockDownloadOperation: ZcashOperation {
     
     override var isConcurrent: Bool { false }
-       
+    
     override var isAsynchronous: Bool { false }
     
     private var downloader: CompactBlockDownloading

--- a/ZcashLightClientKit/Block/Processor/CompactBlockValidationInformation.swift
+++ b/ZcashLightClientKit/Block/Processor/CompactBlockValidationInformation.swift
@@ -41,6 +41,7 @@ class CompactBlockValidationOperation: ZcashOperation {
             let error = CompactBlockValidationError.validationFailed(height: BlockHeight(result))
             self.error = error
             LoggerProxy.debug("block scanning failed with error: \(String(describing: self.error))")
+            self.cancel()
             self.fail()
             return
         }

--- a/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
+++ b/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
@@ -29,9 +29,7 @@ class ZcashOperation: Operation {
         completionBlock = { [weak self] in
             guard let self = self, let handler = self.completionHandler else { return }
             
-            //            self.handlerDispatchQueue.async {
             handler(self.isFinished, self.isCancelled)
-            //            }
         }
     }
     
@@ -47,7 +45,7 @@ class ZcashOperation: Operation {
     }
     
     func shouldCancel() -> Bool {
-        isCancelled || dependencyCancelled()
+        self.error != nil || isCancelled || dependencyCancelled()
     }
     
     func dependencyCancelled() -> Bool {

--- a/ZcashLightClientKitTests/CompactBlockReorgTests.swift
+++ b/ZcashLightClientKitTests/CompactBlockReorgTests.swift
@@ -115,9 +115,10 @@ class CompactBlockReorgTests: XCTestCase {
                    downloadStartedExpect,
                    startedValidatingNotificationExpectation,
                    startedScanningNotificationExpectation,
+                
                    reorgNotificationExpectation,
                    idleNotificationExpectation,
-                   ], timeout: 10,enforceOrder: true)
+                   ], timeout: 3000,enforceOrder: true)
     }
     
     private func expectedBatches(currentHeight: BlockHeight, targetHeight: BlockHeight, batchSize: Int) -> Int {


### PR DESCRIPTION
Reorg could fail without an error message because of the operation that presented the error could be deallocated and nil'd before the error could be captured.

Fix: implement block operations adapters, that serve as safe walls between operations and enforce dependencies. 