### PR TITLE
Remove parameter download steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
 install:
   - ${TRAVIS_BUILD_DIR}/Scripts/travis/rust_setup.sh
   - ${TRAVIS_BUILD_DIR}/Scripts/travis/ZcashLightClientSample_setup.sh
-  - curl https://z.cash/downloads/sapling-output.params > ${TRAVIS_BUILD_DIR}/ZcashLightClientKitTests/sapling-output.params
-  - curl https://z.cash/downloads/sapling-output.params > ${TRAVIS_BUILD_DIR}/ZcashLightClientKitTests/sapling-spend.params
 script:
   - swiftlint
   - travis_wait 60 xcodebuild -quiet -UseModernBuildSystem=NO -workspace ./Example/ZcashLightClientSample/ZcashLightClientSample.xcworkspace -scheme ZcashLightClientSample -destination platform\=iOS\ Simulator,OS\=13.1,name\=iPhone\ 8 build


### PR DESCRIPTION
I think these are needed for running tests, not building, but we're not running tests right now.