### PR TITLE
Update LibRustZcash revision to support canopy on TESTNET

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,15 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bellman"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2s_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -317,10 +317,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ff"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff_derive 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff_derive 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "ff_derive"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "addchain 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -392,10 +392,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "group"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -441,18 +441,18 @@ dependencies = [
 
 [[package]]
 name = "libzcashlc"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "ffi_helpers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "zcash_client_sqlite 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "zcash_proofs 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "zcash_client_sqlite 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "zcash_proofs 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
 ]
 
 [[package]]
@@ -529,11 +529,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "pairing"
 version = "0.16.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -865,53 +865,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zcash_client_backend"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-codegen-pure 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "protobuf 2.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
 ]
 
 [[package]]
 name = "zcash_primitives"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2s_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto_api_chachapoly 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "equihash 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "equihash 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "fpe 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -921,16 +921,16 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942#f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+source = "git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296#18b1ce7401184e86031e6d7ddefa7c8d36929296"
 dependencies = [
- "bellman 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "bellman 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
- "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
+ "pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)",
+ "zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)",
 ]
 
 [metadata]
@@ -947,7 +947,7 @@ dependencies = [
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 "checksum bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
-"checksum bellman 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum bellman 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
@@ -967,21 +967,21 @@ dependencies = [
 "checksum crypto_api_chachapoly 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95b2ad7cab08fd71addba81df5077c49df208effdfb3118a1519f9cdeac5aaf2"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72d337a64190607d4fcca2cb78982c5dd57f4916e19696b48a575fa746b6cb0f"
-"checksum equihash 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum equihash 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
 "checksum failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 "checksum failure_derive 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-"checksum ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
-"checksum ff_derive 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum ff 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
+"checksum ff_derive 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
 "checksum ffi_helpers 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "545c5db858a1f8749e81b22cb9e10a5412c9775441a53c4bd1d1f28531edc843"
 "checksum fpe 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21988a326139165b75e3196bc6962ca638e5fb0c95102fbf152a3743174b01e4"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum gimli 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
-"checksum group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum group 0.6.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
 "checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
@@ -998,7 +998,7 @@ dependencies = [
 "checksum num-traits 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 "checksum object 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-"checksum pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum pairing 0.16.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
 "checksum pkg-config 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 "checksum ppv-lite86 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -1042,7 +1042,7 @@ dependencies = [
 "checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
-"checksum zcash_client_sqlite 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
-"checksum zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
-"checksum zcash_proofs 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=f55f094ef69c2caeaa941bcf851dac8cb5fa9942)" = "<none>"
+"checksum zcash_client_backend 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
+"checksum zcash_client_sqlite 0.0.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
+"checksum zcash_primitives 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"
+"checksum zcash_proofs 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=18b1ce7401184e86031e6d7ddefa7c8d36929296)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzcashlc"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Jack Grigg <jack@z.cash>",
             "Francisco Gindre <francisco@z.cash>",
 ]
@@ -14,31 +14,31 @@ hex = "0.3"
 
 [dependencies.ff]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 
 [dependencies.pairing]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 
 [dependencies.zcash_client_backend]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 
 [dependencies.zcash_client_sqlite]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 [dependencies.zcash_primitives]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 
 [dependencies.zcash_proofs]
 git = "https://github.com/zcash/librustzcash.git"
-rev = "f55f094ef69c2caeaa941bcf851dac8cb5fa9942"
+rev = "18b1ce7401184e86031e6d7ddefa7c8d36929296"
 
 default-features = false
 features = ["local-prover"]

--- a/Example/ZcashLightClientSample/Podfile.lock
+++ b/Example/ZcashLightClientSample/Podfile.lock
@@ -65,10 +65,10 @@ PODS:
     - SwiftNIOTLS (< 3, >= 2.19.0)
   - SwiftProtobuf (1.11.0)
   - ZcashLightClientKit (0.6.0):
-    - gRPC-Swift (~> 1.0.0-alpha.17)
+    - gRPC-Swift (= 1.0.0-alpha.17)
     - SQLite.swift (~> 0.12.2)
   - ZcashLightClientKit/Tests (0.6.0):
-    - gRPC-Swift (~> 1.0.0-alpha.17)
+    - gRPC-Swift (= 1.0.0-alpha.17)
     - SQLite.swift (~> 0.12.2)
 
 DEPENDENCIES:
@@ -140,7 +140,7 @@ SPEC CHECKSUMS:
   SwiftNIOTLS: 9225a214c2483873406322d83c9db3731d8350e9
   SwiftNIOTransportServices: e69704b2d41b68a531bf3aa0177fec81ba1361e6
   SwiftProtobuf: f889fe5772f90ef7d7b8aac352d1fddf39650713
-  ZcashLightClientKit: 2136124b820f1227355e1b8ef078cc0b94276d5f
+  ZcashLightClientKit: 7c6a9a4d6e1420f030baeff07e9e4818f6ec7dc9
 
 PODFILE CHECKSUM: 0055c060ebfda59d4243e428eedc1db06c245f19
 


### PR DESCRIPTION
Support canopy on testnet