### PR TITLE
Synchronizer Enhancements: Operations cancelled when going to background

### DIFF
--- a/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
+++ b/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
@@ -197,6 +197,7 @@ public class CompactBlockProcessor {
     private var config: Configuration = Configuration.standard
     private var queue: OperationQueue = {
         let q = OperationQueue()
+        q.name = "CompactBlockProcessorQueue"
         q.maxConcurrentOperationCount = 1
         return q
     } ()

--- a/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
+++ b/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
@@ -419,8 +419,9 @@ public class CompactBlockProcessor {
         }
         let validateChainOperation = CompactBlockValidationOperation(rustWelding: self.rustBackend, cacheDb: cfg.cacheDb, dataDb: cfg.dataDb)
         
-        let downloadValidateAdapterOperation = BlockOperation {
-            validateChainOperation.error = downloadBlockOperation.error
+        let downloadValidateAdapterOperation = BlockOperation { [weak validateChainOperation, weak downloadBlockOperation] in
+
+            validateChainOperation?.error = downloadBlockOperation?.error
         }
         
         validateChainOperation.completionHandler = { (finished, cancelled) in
@@ -455,8 +456,8 @@ public class CompactBlockProcessor {
         
         let scanBlocksOperation = CompactBlockScanningOperation(rustWelding: self.rustBackend, cacheDb: cfg.cacheDb, dataDb: cfg.dataDb)
         
-        let validateScanningAdapterOperation = BlockOperation {
-            scanBlocksOperation.error = validateChainOperation.error
+        let validateScanningAdapterOperation = BlockOperation { [weak scanBlocksOperation, weak validateChainOperation] in
+            scanBlocksOperation?.error = validateChainOperation?.error
         }
         scanBlocksOperation.startedHandler = { [weak self] in
             self?.state = .scanning
@@ -502,8 +503,8 @@ public class CompactBlockProcessor {
             self.fail(error)
         }
         
-        let scanEnhanceAdapterOperation = BlockOperation {
-            enhanceOperation.error = scanBlocksOperation.error
+        let scanEnhanceAdapterOperation = BlockOperation { [weak enhanceOperation, weak scanBlocksOperation] in
+            enhanceOperation?.error = scanBlocksOperation?.error
         }
         
         downloadValidateAdapterOperation.addDependency(downloadBlockOperation)

--- a/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
+++ b/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
@@ -39,6 +39,11 @@ class ZcashOperation: Operation {
     }
     
     override func start() {
+        guard !shouldCancel() else {
+            LoggerProxy.debug("\(self) cancelled")
+            cancel()
+            return
+        }
         LoggerProxy.debug("\(self) started")
         startedHandler?()
         super.start()

--- a/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
+++ b/ZcashLightClientKit/Block/Processor/ZcashOperation.swift
@@ -39,11 +39,6 @@ class ZcashOperation: Operation {
     }
     
     override func start() {
-        guard !shouldCancel() else {
-            LoggerProxy.debug("\(self) cancelled")
-            cancel()
-            return
-        }
         LoggerProxy.debug("\(self) started")
         startedHandler?()
         super.start()

--- a/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
+++ b/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
@@ -90,7 +90,6 @@ public class SDKSynchronizer: Synchronizer {
     
     private var transactionManager: OutboundTransactionManager
     private var transactionRepository: TransactionRepository
-    private var isFirstApplicationStart = true
     var taskIdentifier: UIBackgroundTaskIdentifier = .invalid
     
     private var isBackgroundAllowed: Bool {
@@ -394,10 +393,7 @@ public class SDKSynchronizer: Synchronizer {
     }
     
     @objc func applicationWillEnterForeground(_ notification: Notification) {
-        guard !self.isFirstApplicationStart else {
-            self.isFirstApplicationStart = false
-            return
-        }
+
         let status = self.status
         LoggerProxy.debug("applicationWillEnterForeground")
         invalidateBackgroundActivity()

--- a/ZcashLightClientKitTests/TestCoordinator.swift
+++ b/ZcashLightClientKitTests/TestCoordinator.swift
@@ -117,7 +117,7 @@ class TestCoordinator {
         self.completionHandler = completion
         self.errorHandler = error
         
-        try synchronizer.start()
+        try synchronizer.start(retry: true)
     }
     
     


### PR DESCRIPTION
closes #176 
closes https://github.com/zcash/zcash-ios-wallet/issues/137
closes https://github.com/zcash/zcash-ios-wallet/issues/123

Reported by: Unstoppable Wallet

> When the app goes to background, it calls synchronizer.stop, invalidates timer and sets state to stopped. But ZCashOperation class calls start() and it is trying to download more data with new state 'validating'. After canceling tasks, kit does not set 'stopped' state again. So, when we come back from background, state has not setted to 'stopped'. Is it right behavior?

````

18:23:20.046 💚 DEBUG  ZcashOperation  start()  42 : <ZcashLightClientKit.CompactBlockDownloadOperation: 0x135ec0de0>{name = 'Download Operation: 1038100...1038199'} started
(CBProcessor) set state: downloading
==> call synchronizer.stop
=====> CompactBlockProcessor. remove timer!
=====> CompactBlockProcessor. cancel all operations!
(CBProcessor) set state: stopped
18:23:20.640 💚 DEBUG  ZcashOperation  start()  42 : <ZcashLightClientKit.CompactBlockValidationOperation: 0x135eac900> started
(CBProcessor) set state: validating
18:23:20.641 💚 DEBUG  CompactBlockProcessor  processNewBlocks(range:)  431 : Warning: validateChainOperation operation cancelled
18:23:20.641 💚 DEBUG  ZcashOperation  start()  42 : <ZcashLightClientKit.CompactBlockScanningOperation: 0x135ec0960> started
(CBProcessor) set state: scanning
18:23:20.641 💚 DEBUG  CompactBlockProcessor  processNewBlocks(range:)  472 : Warning: scanBlocksOperation operation cancelled
18:23:20.642 💚 DEBUG  ZcashOperation  start()  42 : <ZcashLightClientKit.CompactBlockEnhancementOperation: 0x135e0ca30> started
18:23:20.642 💚 DEBUG  CompactBlockProcessor  processNewBlocks(range:)  487 : Started Enhancing range: 1038100...1038199
18:23:20.642 💚 DEBUG  CompactBlockProcessor  processNewBlocks(range:)  497 : Warning: enhance operation on range 1038100...1038199 cancelled
==> willEnterForeground(Synchronizer): syncing from syncing!
==> willEnterForeground(App): current status = syncing
````

I think I figured out what was going on with the sync being broken when backgrounding. And if that's the case the complete fix would involve some thinking in the separation of concerns between the SDKSynchronizer that is a OS aware wrapper for the CompactBlockProcessor and the Application

In my case I'm using Swift UI supporting iOS 13+, which means I use that mix of ApplicationDelegate + SceneDelegate.

So the ECC Wallet launch cycle is like AppDelegate.didFinishLaunchingWithOptions() -> then SceneDelegate.didConnectScene() -> Spawn the first screen -> which can be the home screen for users that had created or restored a wallet previously or the 'welcome screen'.


the origin of that "isFirstApplicationLaunch"  was indeed a bugfix on the wallet that ended up in the SDKSynchronizer when it shouldn't have.

ECC Wallet was starting the SDKSynchronizer too early in the launch cycle. So the `sdksynchronizer` would have already started and subscribed to UIApplication events before applicationWillEnterForeground notification was sent by the OS, so we could have a duplicate start that was not caught by the guard statements. So the processor would attempt to download a block range that was already downloaded but not yet accounted for and then the whole processing went down the hill with it.

so, maybe it's more of a PR/Issue kind of debate, but in the end the Key question is: Should the SDKSynchronizer be aware of App Lifecycle and take action to extend background tasks or auto resume? or should that be a problem of the client application instead?

