### PR TITLE
Allow Wallet developers to rewind synchronizer and (eventually) rescan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+checksum = "6c7f7096bc256f5e5cb960f60dfc4f4ef979ca65abe7fb9d5a4f77150d3783d4"
 
 [[package]]
 name = "bellman"
@@ -437,7 +437,8 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "equihash"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=42f15a575e309b5a634450280d4cfb8d374addbf#42f15a575e309b5a634450280d4cfb8d374addbf"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4127688f6177e3f57521881cb1cfd90d1228214f9dc43b8efe6f6c6948cd8280"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1532,8 +1533,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=42f15a575e309b5a634450280d4cfb8d374addbf#42f15a575e309b5a634450280d4cfb8d374addbf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe10ae6417779fbd7903fdbef0c32d26bcdcf3b3a521d6372be8b55ce63410f5"
 dependencies = [
  "base64",
  "bech32",
@@ -1555,8 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.2.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=42f15a575e309b5a634450280d4cfb8d374addbf#42f15a575e309b5a634450280d4cfb8d374addbf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852ba85adbb6148d81fa19db895aa17ae6365db293738a706d5ddba403b4eb4c"
 dependencies = [
  "bech32",
  "bs58 0.4.0",
@@ -1573,8 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=42f15a575e309b5a634450280d4cfb8d374addbf#42f15a575e309b5a634450280d4cfb8d374addbf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926666fae42e08d65ddba7c3808873d1e6cd6e7dd86e84f51a909c79b5fe285c"
 dependencies = [
  "aes",
  "bitvec 0.18.5",
@@ -1600,8 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=42f15a575e309b5a634450280d4cfb8d374addbf#42f15a575e309b5a634450280d4cfb8d374addbf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc3cd16a4efbebf925756f339d01e876816d37d1f458bd8243edb3bd8dbad74b"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ build = "rust/build.rs"
 failure = "0.1"
 ffi_helpers = "0.2"
 hex = "0.4"
-zcash_client_backend = "0.4"
-zcash_client_sqlite = "0.2.1"
-zcash_primitives = "0.4"
+zcash_client_backend = "0.5"
+zcash_client_sqlite = "0.3.0"
+zcash_primitives = "0.5"
 
 #### Temporary additions: ####################################
 bitvec = "0.18"
@@ -29,7 +29,7 @@ funty = "=1.1.0"
 ##############################################################
 
 [dependencies.zcash_proofs]
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["local-prover"]
 
@@ -43,12 +43,6 @@ crate-type = ["staticlib"]
 
 [profile.release]
 lto = true
-
-[patch.crates-io]
-zcash_client_backend = {git = "https://github.com/zcash/librustzcash.git", rev = "42f15a575e309b5a634450280d4cfb8d374addbf"}
-zcash_client_sqlite = {git = "https://github.com/zcash/librustzcash.git", rev = "42f15a575e309b5a634450280d4cfb8d374addbf"}
-zcash_primitives = {git = "https://github.com/zcash/librustzcash.git", rev = "42f15a575e309b5a634450280d4cfb8d374addbf"}
-zcash_proofs = {git = "https://github.com/zcash/librustzcash.git", rev = "42f15a575e309b5a634450280d4cfb8d374addbf"}
 
 [features]
 mainnet = ["zcash_client_sqlite/mainnet"]

--- a/ZcashLightClientKit/Entity/TransactionEntity.swift
+++ b/ZcashLightClientKit/Entity/TransactionEntity.swift
@@ -56,6 +56,18 @@ public extension TransactionEntity {
         
         return true
     }
+    
+    var anchor: BlockHeight? {
+        if let minedHeight = self.minedHeight, minedHeight != -1 {
+            return max(minedHeight - ZcashSDK.DEFAULT_STALE_TOLERANCE, ZcashSDK.SAPLING_ACTIVATION_HEIGHT)
+        }
+        
+        if let expiryHeight = self.expiryHeight, expiryHeight != -1 {
+            return max(expiryHeight - ZcashSDK.EXPIRY_OFFSET - ZcashSDK.DEFAULT_STALE_TOLERANCE, ZcashSDK.SAPLING_ACTIVATION_HEIGHT)
+        }
+        
+        return nil
+    }
 }
 /**
  Abstract representation of all transaction types

--- a/ZcashLightClientKit/Synchronizer.swift
+++ b/ZcashLightClientKit/Synchronizer.swift
@@ -130,7 +130,14 @@ public protocol Synchronizer {
      Blocking
      */
     func latestHeight() throws -> BlockHeight
+    
+    /**
+     Stops the synchronizer, and rescans this
+     */
+    func rewind(_ policy: RewindPolicy) throws
 }
+
+
 
 /**
  The Status of the synchronizer
@@ -169,4 +176,15 @@ public enum TransactionKind {
     case sent
     case received
     case all
+}
+
+
+/**
+ Type of rescan
+ */
+
+public enum RewindPolicy {
+    case birthday
+    case height(blockheight: BlockHeight)
+    case transaction(_ transaction: TransactionEntity)
 }

--- a/ZcashLightClientKit/Synchronizer.swift
+++ b/ZcashLightClientKit/Synchronizer.swift
@@ -22,6 +22,8 @@ public enum SynchronizerError: Error {
     case uncategorized(underlyingError: Error)
     case criticalError
     case parameterMissing(underlyingError: Error)
+    case rewindError(underlyingError: Error)
+    case rewindErrorUnknownArchorHeight
 }
 
 /**
@@ -132,7 +134,7 @@ public protocol Synchronizer {
     func latestHeight() throws -> BlockHeight
     
     /**
-     Stops the synchronizer, and rescans this
+     Stops the synchronizer, and rescans the known blocks with the current keys
      */
     func rewind(_ policy: RewindPolicy) throws
 }

--- a/ZcashLightClientKit/Synchronizer.swift
+++ b/ZcashLightClientKit/Synchronizer.swift
@@ -134,7 +134,11 @@ public protocol Synchronizer {
     func latestHeight() throws -> BlockHeight
     
     /**
-     Stops the synchronizer, and rescans the known blocks with the current keys
+     Stops the synchronizer and rescans the known blocks with the current keys.
+     - Parameter policy: the rewind policy
+     - Throws rewindErrorUnknownArchorHeight when the rewind points to an invalid height
+     - Throws rewindError for other errors
+     - Note rewind does not trigger notifications as a reorg would. You need to restart the synchronizer afterwards
      */
     func rewind(_ policy: RewindPolicy) throws
 }
@@ -182,7 +186,10 @@ public enum TransactionKind {
 
 
 /**
- Type of rescan
+ Type of rewind available
+    birthday: rewinds the local state to this wallet's birthday
+    height: rewinds to an arbitrary blockheight
+    transaction: rewinds to the mined height of the provided transaction.
  */
 
 public enum RewindPolicy {

--- a/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
+++ b/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
@@ -438,12 +438,12 @@ public class SDKSynchronizer: Synchronizer {
             
         }
         
-        guard let height = height else {
+        guard let h = height else {
             throw SynchronizerError.rewindErrorUnknownArchorHeight
         }
         do {
-            try processor.rewindTo(height)
-            try self.transactionManager.handleReorg(at: height)
+            try processor.rewindTo(h)
+            try self.transactionManager.handleReorg(at: h)
         } catch {
             throw SynchronizerError.rewindError(underlyingError: error)
         }

--- a/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
+++ b/ZcashLightClientKit/UIKit/Synchronizer/SDKSynchronizer.swift
@@ -415,6 +415,18 @@ public class SDKSynchronizer: Synchronizer {
         try initializer.downloader.latestBlockHeight()
     }
     
+    public func rewind(_ policy: RewindPolicy) throws {
+//        self.stop()
+//
+//        switch policy {
+//        case .birthday:
+//            
+//
+//        default:
+//            <#code#>
+//        }
+    }
+    
     // MARK: notify state
     private func notify(progress: Float, height: BlockHeight) {
         NotificationCenter.default.post(name: Notification.Name.synchronizerProgressUpdated, object: self, userInfo: [

--- a/ZcashLightClientKitTests/RewindRescanTests.swift
+++ b/ZcashLightClientKitTests/RewindRescanTests.swift
@@ -1,0 +1,187 @@
+//
+//  XCTRewindRescanTests.swift
+//  ZcashLightClientKit-Unit-Tests
+//
+//  Created by Francisco Gindre on 3/25/21.
+//
+
+import XCTest
+@testable import ZcashLightClientKit
+class RewindRescanTests: XCTestCase {
+    var seedPhrase = "still champion voice habit trend flight survey between bitter process artefact blind carbon truly provide dizzy crush flush breeze blouse charge solid fish spread" //TODO: Parameterize this from environment?
+    
+    let testRecipientAddress = "zs17mg40levjezevuhdp5pqrd52zere7r7vrjgdwn5sj4xsqtm20euwahv9anxmwr3y3kmwuz8k55a" //TODO: Parameterize this from environment
+    
+    let sendAmount: Int64 = 1000
+    var birthday: BlockHeight = 663150
+    let defaultLatestHeight: BlockHeight = 663175
+    var coordinator: TestCoordinator!
+    var syncedExpectation = XCTestExpectation(description: "synced")
+    var sentTransactionExpectation = XCTestExpectation(description: "sent")
+    var expectedReorgHeight: BlockHeight = 665188
+    var expectedRewindHeight: BlockHeight = 665188
+    var reorgExpectation: XCTestExpectation = XCTestExpectation(description: "reorg")
+    override func setUpWithError() throws {
+        
+        coordinator = try TestCoordinator(
+            seed: seedPhrase,
+            walletBirthday: birthday,
+            channelProvider: ChannelProvider()
+        )
+        try coordinator.reset(saplingActivation: 663150)
+    }
+    
+    override func tearDownWithError() throws {
+        NotificationCenter.default.removeObserver(self)
+        try coordinator.stop()
+        try? FileManager.default.removeItem(at: coordinator.databases.cacheDB)
+        try? FileManager.default.removeItem(at: coordinator.databases.dataDB)
+        try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
+    }
+
+    
+    func handleError(_ error: Error?) {
+        guard let testError = error else {
+            XCTFail("failed with nil error")
+            return
+        }
+        XCTFail("Failed with error: \(testError)")
+    }
+    
+    func testBirthdayRescan() throws {
+        // 1 sync and get spendable funds
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
+        
+        try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
+        
+        sleep(1)
+        let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            firstSyncExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [firstSyncExpectation], timeout: 12)
+        // 2 check that there are no unconfirmed funds
+        
+        let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
+        XCTAssertEqual(verifiedBalance, totalBalance)
+        
+        // rewind to birthday
+        try coordinator.synchronizer.rewind(.birthday)
+        
+        // assert that after the new height is
+        XCTAssertEqual(try coordinator.latestHeight(), birthday)
+        
+        let secondScanExpectation = XCTestExpectation(description: "rescan")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            secondScanExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [secondScanExpectation], timeout: 12)
+        
+        // verify that the balance still adds up
+        
+        XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
+        
+    }
+    
+    
+    func testRescanToHeight() throws {
+        // 1 sync and get spendable funds
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
+        
+        try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
+        
+        sleep(1)
+        let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            firstSyncExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [firstSyncExpectation], timeout: 12)
+        // 2 check that there are no unconfirmed funds
+        
+        let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
+        XCTAssertEqual(verifiedBalance, totalBalance)
+        
+        // rewind to birthday
+        let targetRewind = BlockHeight(663160)
+        try coordinator.synchronizer.rewind(.height(blockheight: targetRewind))
+        
+        // assert that after the new height is
+        XCTAssertEqual(try coordinator.latestHeight(), targetRewind)
+        
+        let secondScanExpectation = XCTestExpectation(description: "rescan")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            secondScanExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [secondScanExpectation], timeout: 12)
+        
+        // verify that the balance still adds up
+        
+        XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
+        
+    }
+
+    func testRescanToTransaction() throws {
+        // 1 sync and get spendable funds
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
+        
+        try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
+        
+        sleep(1)
+        let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            firstSyncExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [firstSyncExpectation], timeout: 12)
+        // 2 check that there are no unconfirmed funds
+        
+        let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
+        XCTAssertEqual(verifiedBalance, totalBalance)
+        
+        // rewind to transaction
+        
+        
+        guard let transaction = try coordinator.synchronizer.allClearedTransactions().first else {
+            XCTFail("failed to get a transaction to rewind to")
+            return
+        }
+        
+        try coordinator.synchronizer.rewind(.transaction(transaction.transactionEntity))
+        
+        // assert that after the new height is
+        XCTAssertEqual(try coordinator.latestHeight(), transaction.minedHeight)
+        
+        let secondScanExpectation = XCTestExpectation(description: "rescan")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            secondScanExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [secondScanExpectation], timeout: 12)
+        
+        // verify that the balance still adds up
+        
+        XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
+        
+    }
+
+
+}

--- a/ZcashLightClientKitTests/RewindRescanTests.swift
+++ b/ZcashLightClientKitTests/RewindRescanTests.swift
@@ -53,7 +53,8 @@ class RewindRescanTests: XCTestCase {
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
         
         try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
-        
+        let initialVerifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let initialTotalBalance = coordinator.synchronizer.initializer.getBalance()
         sleep(1)
         let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
         
@@ -62,10 +63,9 @@ class RewindRescanTests: XCTestCase {
         }, error: handleError)
         
         wait(for: [firstSyncExpectation], timeout: 12)
-        // 2 check that there are no unconfirmed funds
-        
         let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
         let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        // 2 check that there are no unconfirmed funds
         XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
         XCTAssertEqual(verifiedBalance, totalBalance)
         
@@ -73,8 +73,11 @@ class RewindRescanTests: XCTestCase {
         try coordinator.synchronizer.rewind(.birthday)
         
         // assert that after the new height is
-        XCTAssertEqual(try coordinator.latestHeight(), birthday)
+        XCTAssertEqual(try coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight(),self.birthday)
         
+        // check that the balance is cleared
+        XCTAssertEqual(initialVerifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(initialTotalBalance, coordinator.synchronizer.initializer.getBalance())
         let secondScanExpectation = XCTestExpectation(description: "rescan")
         
         try coordinator.sync(completion: { (synchronizer) in
@@ -84,7 +87,6 @@ class RewindRescanTests: XCTestCase {
         wait(for: [secondScanExpectation], timeout: 12)
         
         // verify that the balance still adds up
-        
         XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
         XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
         
@@ -96,7 +98,8 @@ class RewindRescanTests: XCTestCase {
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
         
         try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
-        
+        let initialVerifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let initialTotalBalance = coordinator.synchronizer.initializer.getBalance()
         sleep(1)
         let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
         
@@ -105,20 +108,22 @@ class RewindRescanTests: XCTestCase {
         }, error: handleError)
         
         wait(for: [firstSyncExpectation], timeout: 12)
-        // 2 check that there are no unconfirmed funds
-        
         let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
         let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        // 2 check that there are no unconfirmed funds
         XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
         XCTAssertEqual(verifiedBalance, totalBalance)
         
         // rewind to birthday
-        let targetRewind = BlockHeight(663160)
-        try coordinator.synchronizer.rewind(.height(blockheight: targetRewind))
+        let targetHeight: BlockHeight = 663160
+        try coordinator.synchronizer.rewind(.height(blockheight: targetHeight))
         
         // assert that after the new height is
-        XCTAssertEqual(try coordinator.latestHeight(), targetRewind)
+        XCTAssertEqual(try coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight(),targetHeight)
         
+        // check that the balance is cleared
+        XCTAssertEqual(initialVerifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(initialTotalBalance, coordinator.synchronizer.initializer.getBalance())
         let secondScanExpectation = XCTestExpectation(description: "rescan")
         
         try coordinator.sync(completion: { (synchronizer) in
@@ -128,7 +133,6 @@ class RewindRescanTests: XCTestCase {
         wait(for: [secondScanExpectation], timeout: 12)
         
         // verify that the balance still adds up
-        
         XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
         XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
         
@@ -139,6 +143,58 @@ class RewindRescanTests: XCTestCase {
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
         
         try coordinator.applyStaged(blockheight: defaultLatestHeight + 50)
+      
+        sleep(1)
+        let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            firstSyncExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [firstSyncExpectation], timeout: 12)
+        let verifiedBalance = coordinator.synchronizer.initializer.getVerifiedBalance()
+        let totalBalance = coordinator.synchronizer.initializer.getBalance()
+        // 2 check that there are no unconfirmed funds
+        XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
+        XCTAssertEqual(verifiedBalance, totalBalance)
+        
+        // rewind to transaction
+        guard let transaction = try coordinator.synchronizer.allClearedTransactions().first else {
+            XCTFail("failed to get a transaction to rewind to")
+            return
+        }
+
+        try coordinator.synchronizer.rewind(.transaction(transaction.transactionEntity))
+
+        
+        // assert that after the new height is
+        XCTAssertEqual(try coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight(),transaction.transactionEntity.anchor)
+        
+        let secondScanExpectation = XCTestExpectation(description: "rescan")
+        
+        try coordinator.sync(completion: { (synchronizer) in
+            secondScanExpectation.fulfill()
+        }, error: handleError)
+        
+        wait(for: [secondScanExpectation], timeout: 12)
+        
+        // verify that the balance still adds up
+        XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
+        XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
+        
+    }
+    
+    func testRewindAfterSendingTransaction() throws {
+        let notificationHandler = SDKSynchonizerListener()
+        let foundTransactionsExpectation = XCTestExpectation(description: "found transactions expectation")
+        let transactionMinedExpectation = XCTestExpectation(description: "transaction mined expectation")
+        
+        // 0 subscribe to updated transactions events
+        notificationHandler.subscribeToSynchronizer(coordinator.synchronizer)
+        // 1 sync and get spendable funds
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service)
+        
+        try coordinator.applyStaged(blockheight: defaultLatestHeight + 10)
         
         sleep(1)
         let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
@@ -155,33 +211,127 @@ class RewindRescanTests: XCTestCase {
         XCTAssertTrue(verifiedBalance > ZcashSDK.defaultFee())
         XCTAssertEqual(verifiedBalance, totalBalance)
         
-        // rewind to transaction
+        let maxBalance = verifiedBalance - Int64(ZcashSDK.defaultFee())
         
-        
-        guard let transaction = try coordinator.synchronizer.allClearedTransactions().first else {
-            XCTFail("failed to get a transaction to rewind to")
+        // 3 create a transaction for the max amount possible
+        // 4 send the transaction
+        guard let spendingKey = coordinator.spendingKeys?.first else {
+            XCTFail("failed to create spending keys")
+            return
+        }
+        var pendingTx: PendingTransactionEntity?
+        coordinator.synchronizer.sendToAddress(spendingKey: spendingKey,
+                                               zatoshi: maxBalance,
+                                               toAddress: testRecipientAddress,
+                                               memo: "test send \(self.description) \(Date().description)",
+        from: 0) { result in
+            switch result {
+            case .failure(let error):
+                XCTFail("sendToAddress failed: \(error)")
+            case .success(let transaction):
+                pendingTx = transaction
+            }
+            self.sentTransactionExpectation.fulfill()
+        }
+        wait(for: [sentTransactionExpectation], timeout: 20)
+        guard let pendingTx = pendingTx else {
+            XCTFail("transaction creation failed")
             return
         }
         
-        try coordinator.synchronizer.rewind(.transaction(transaction.transactionEntity))
+        notificationHandler.synchronizerMinedTransaction = { tx in
+            XCTAssertNotNil(tx.rawTransactionId)
+            XCTAssertNotNil(pendingTx.rawTransactionId)
+            XCTAssertEqual(tx.rawTransactionId, pendingTx.rawTransactionId)
+            transactionMinedExpectation.fulfill()
+        }
         
-        // assert that after the new height is
-        XCTAssertEqual(try coordinator.latestHeight(), transaction.minedHeight)
         
-        let secondScanExpectation = XCTestExpectation(description: "rescan")
+        // 5 apply to height
+        // 6 mine the block
+        guard let rawTx = try coordinator.getIncomingTransactions()?.first else {
+            XCTFail("no incoming transaction after")
+            return
+        }
+        
+        let latestHeight = try coordinator.latestHeight()
+        let sentTxHeight = latestHeight + 1
+        
+        notificationHandler.transactionsFound = { txs in
+            let foundTx = txs.first(where: { $0.rawTransactionId ==  pendingTx.rawTransactionId})
+            XCTAssertNotNil(foundTx)
+            XCTAssertEqual(foundTx?.minedHeight, sentTxHeight)
+            
+            foundTransactionsExpectation.fulfill()
+        }
+        try coordinator.stageBlockCreate(height: sentTxHeight, count: 100)
+        sleep(1)
+        try coordinator.stageTransaction(rawTx, at: sentTxHeight)
+        try coordinator.applyStaged(blockheight: sentTxHeight)
+        sleep(2)
+        
+        
+        let mineExpectation = XCTestExpectation(description: "mineTxExpectation")
         
         try coordinator.sync(completion: { (synchronizer) in
-            secondScanExpectation.fulfill()
-        }, error: handleError)
+            let p = synchronizer.pendingTransactions.first(where: {$0.rawTransactionId == pendingTx.rawTransactionId})
+            XCTAssertNotNil(p, "pending transaction should have been mined by now")
+            XCTAssertTrue(p?.isMined ?? false)
+            XCTAssertEqual(p?.minedHeight, sentTxHeight)
+            mineExpectation.fulfill()
+            
+        }, error: { (error) in
+            guard let e = error else {
+                XCTFail("unknown error syncing after sending transaction")
+                return
+            }
+            
+            XCTFail("Error: \(e)")
+        })
         
-        wait(for: [secondScanExpectation], timeout: 12)
+        wait(for: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
         
-        // verify that the balance still adds up
+        // 7 advance to confirmation
         
-        XCTAssertEqual(verifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
-        XCTAssertEqual(totalBalance, coordinator.synchronizer.initializer.getBalance())
+        try coordinator.applyStaged(blockheight: sentTxHeight + 10)
         
+        sleep(2)
+        
+        // rewind 5 blocks prior to sending
+        
+        try coordinator.synchronizer.rewind(.height(blockheight: sentTxHeight - 5))
+        
+        guard let np = try coordinator.synchronizer.allPendingTransactions().first(where: { $0.rawTransactionId == pendingTx.rawTransactionId}) else {
+            XCTFail("sent pending transaction not found after rewind")
+            return
+        }
+        
+        XCTAssertFalse(np.isMined)
+        let confirmExpectation = XCTestExpectation(description: "confirm expectation")
+        notificationHandler.transactionsFound = { txs in
+            XCTAssertEqual(txs.count, 1)
+            guard let t = txs.first else {
+                XCTFail("should have found sent transaction but didn't")
+                return
+            }
+            XCTAssertEqual(t.rawTransactionId, pendingTx.rawTransactionId,"should have mined sent transaction but didn't")
+        }
+        notificationHandler.synchronizerMinedTransaction = { tx in
+            XCTFail("We shouldn't find any mined transactions at this point but found \(tx)")
+        }
+        try coordinator.sync(completion: { synchronizer in
+            confirmExpectation.fulfill()
+        }, error: { e in
+            self.handleError(e)
+        })
+        
+        wait(for: [confirmExpectation], timeout: 10)
+        
+        let confirmedPending = try coordinator.synchronizer.allPendingTransactions().first(where: { $0.rawTransactionId == pendingTx.rawTransactionId})
+        
+        XCTAssertNil(confirmedPending, "pending, now confirmed transaction found")
+        
+        XCTAssertEqual(coordinator.synchronizer.initializer.getBalance(), 0)
+        XCTAssertEqual(coordinator.synchronizer.initializer.getVerifiedBalance(), 0)
     }
-
-
 }


### PR DESCRIPTION
closes #245 