### PR TITLE
[#388] Integrate libzcashlc 0.0.3 to support v5 transaction parsing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,9 +86,9 @@
         "package": "libzcashlc",
         "repositoryURL": "https://github.com/zcash-hackworks/zcash-light-client-ffi.git",
         "state": {
-          "branch": "main",
-          "revision": "e5aaf60faf16554e47e4bb123a8b4e5c22475e9f",
-          "version": null
+          "branch": null,
+          "revision": "b7e8a2abab84c44046b4afe4ee4522a0fa2fcc7f",
+          "version": "0.0.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.13.0"),
-        .package(name:"libzcashlc", url: "https://github.com/zcash-hackworks/zcash-light-client-ffi.git", branch: "main"),
+        .package(name:"libzcashlc", url: "https://github.com/zcash-hackworks/zcash-light-client-ffi.git", from: "0.0.3"),
     ],
     targets: [
         .target(

--- a/ZcashLightClientKit.podspec
+++ b/ZcashLightClientKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'ZcashLightClientKit'
-    s.version          = '0.13.1-beta'
+    s.version          = '0.14.0-beta'
     s.summary          = 'Zcash Light Client wallet SDK for iOS'
   
     s.description      = <<-DESC

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+# 0.14.0-beta
+- [#388] Integrate libzcashlc 0.0.3 to support v5 transaction parsing on NU5 activation
 # 0.13.1-beta
 - [#326] Load Checkpoint files from bundle.
 This is great news! now checkpoints are loaded from files on the bundle instead of


### PR DESCRIPTION
Closes #389 
This solves a problem where an NU5 aware wallet would receive a
v5 transaction with sapling funds and wouldn’t be able to
enhance it by decrypting the full transaction.

This works in conjunction with lightwalletd version v0.4.11 and .12
see https://github.com/zcash/lightwalletd/releases/tag/v0.4.12
and https://github.com/zcash/lightwalletd/releases/tag/v0.4.11
for details on how to upgrade your light client infrastructure.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).
