### PR TITLE
435 thread sanitizer issue

### DIFF
--- a/Sources/ZcashLightClientKit/Block/DatabaseStorage/CompactBlockStorage.swift
+++ b/Sources/ZcashLightClientKit/Block/DatabaseStorage/CompactBlockStorage.swift
@@ -86,7 +86,7 @@ extension CompactBlockStorage: CompactBlockRepository {
     }
     
     func latestHeight(result: @escaping (Swift.Result<BlockHeight, Error>) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .default).async {
             do {
                 result(.success(try self.latestBlockHeight()))
             } catch {
@@ -100,7 +100,7 @@ extension CompactBlockStorage: CompactBlockRepository {
     }
     
     func write(blocks: [ZcashCompactBlock], completion: ((Error?) -> Void)?) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .default).async {
             do {
                 try self.insert(blocks)
                 completion?(nil)
@@ -111,7 +111,7 @@ extension CompactBlockStorage: CompactBlockRepository {
     }
     
     func rewind(to height: BlockHeight, completion: ((Error?) -> Void)?) {
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .default).async {
             do {
                 try self.rewind(to: height)
                 completion?(nil)

--- a/Sources/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
@@ -322,9 +322,11 @@ public class CompactBlockProcessor {
             self.stop()
         }
     }
+
     var maxAttemptsReached: Bool {
         self.retryAttempts >= self.config.retries
     }
+
     var shouldStart: Bool {
         switch self.state {
         case .stopped, .synced, .error:
@@ -335,7 +337,7 @@ public class CompactBlockProcessor {
     }
 
     private var service: LightWalletService
-    private var downloader: CompactBlockDownloading
+    private(set) var downloader: CompactBlockDownloading
     private var storage: CompactBlockStorage
     private var transactionRepository: TransactionRepository
     private var accountRepository: AccountRepository
@@ -1130,7 +1132,8 @@ public class CompactBlockProcessor {
         case .downloading:
             NotificationCenter.default.post(name: Notification.Name.blockProcessorStartedDownloading, object: self)
         case .synced:
-            NotificationCenter.default.post(name: Notification.Name.blockProcessorFinished, object: self)
+            // transition to this state is handled by `processingFinished(height: BlockHeight)`
+            break
         case .error(let err):
             notifyError(err)
         case .scanning:

--- a/Sources/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/CompactBlockProcessor.swift
@@ -1396,7 +1396,7 @@ extension CompactBlockProcessor {
             queue: DispatchQueue?,
             result: @escaping (Result<FigureNextBatchOperation.NextState, Error>) -> Void
         ) {
-            let dispatchQueue = queue ?? DispatchQueue.global(qos: .userInitiated)
+            let dispatchQueue = queue ?? DispatchQueue.global(qos: .default)
             
             dispatchQueue.async {
                 do {

--- a/Sources/ZcashLightClientKit/DAO/PagedTransactionDao.swift
+++ b/Sources/ZcashLightClientKit/DAO/PagedTransactionDao.swift
@@ -50,7 +50,7 @@ class PagedTransactionDAO: PaginatedTransactionRepository {
     }
     
     func page(_ number: Int, result: @escaping (Result<[TransactionEntity]?, Error>) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self = self else { return }
             do {
                 result(.success(try self.page(number)))

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -442,16 +442,12 @@ public class SDKSynchronizer: Synchronizer {
     }
     
     @objc func processorFinished(_ notification: Notification) {
-        // FIX: Pending transaction updates fail if done from another thread. Improvement needed: explicitly define queues for sql repositories
-            
-//        DispatchQueue.main.async { [weak self] in
-//            guard let self = self else { return }
-            if let blockHeight = notification.userInfo?[CompactBlockProcessorNotificationKey.latestScannedBlockHeight] as? BlockHeight {
-                self.latestScannedHeight = blockHeight
-            }
-            self.refreshPendingTransactions()
-            self.status = .synced
-//        }
+        // FIX: Pending transaction updates fail if done from another thread. Improvement needed: explicitly define queues for sql repositories see: https://github.com/zcash/ZcashLightClientKit/issues/450
+        if let blockHeight = notification.userInfo?[CompactBlockProcessorNotificationKey.latestScannedBlockHeight] as? BlockHeight {
+            self.latestScannedHeight = blockHeight
+        }
+        self.refreshPendingTransactions()
+        self.status = .synced
     }
     
     @objc func processorTransitionUnknown(_ notification: Notification) {

--- a/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
@@ -35,7 +35,7 @@ class PersistentTransactionManager: OutboundTransactionManager {
         self.encoder = encoder
         self.service = service
         self.network = networkType
-        self.queue = DispatchQueue.init(label: "PersistentTransactionManager.serial.queue", qos: .userInitiated)
+        self.queue = DispatchQueue.init(label: "PersistentTransactionManager.serial.queue", qos: .default)
     }
     
     func initSpend(

--- a/Tests/TestUtils/FakeService.swift
+++ b/Tests/TestUtils/FakeService.swift
@@ -111,7 +111,7 @@ class MockLightWalletService: LightWalletService {
     }
     
     func submit(spendTransaction: Data, result: @escaping (Result<LightWalletServiceResponse, LightWalletServiceError>) -> Void) {
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + 1) {
             result(.success(LightWalletServiceMockResponse(errorCode: 0, errorMessage: "", unknownFields: UnknownStorage())))
         }
     }


### PR DESCRIPTION
Closes #435 (partially)

This commit is mostly motivated from Thread sanitizer warnings from ECC Wallet.

There is yet one outstanding warning caused by Swift-GRPC which needs that the stack is initialized on a second thread with .default QoS. 

Wallets using Combine need to gather information from several notification when in fact that information originates at the same time. We gathered all that info and created a SynchronizerState struct that condenses wallet balance, scanned height, etc. this allows these wallets not to poll the synchronizer for info unnecessarily.


This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.