### PR TITLE
[#541] Initialise gRPC on a separate thread

### DIFF
--- a/Sources/ZcashLightClientKit/Service/LightWalletGRPCService.swift
+++ b/Sources/ZcashLightClientKit/Service/LightWalletGRPCService.swift
@@ -10,6 +10,7 @@ import Foundation
 import GRPC
 import NIO
 import NIOHPACK
+import NIOTransportServices
 
 public typealias Channel = GRPC.GRPCChannel
 
@@ -127,8 +128,8 @@ public class LightWalletGRPCService {
         self.singleCallTimeout = TimeLimit.timeout(.milliseconds(singleCallTimeout))
 
         let connectionBuilder = secure ?
-        ClientConnection.usingPlatformAppropriateTLS(for: MultiThreadedEventLoopGroup(numberOfThreads: 1)) :
-        ClientConnection.insecure(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+        ClientConnection.usingPlatformAppropriateTLS(for: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)) :
+        ClientConnection.insecure(group: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default))
 
         let channel = connectionBuilder
             .withConnectivityStateDelegate(connectionManager, executingOn: queue)

--- a/Tests/TestUtils/Tests+Utils.swift
+++ b/Tests/TestUtils/Tests+Utils.swift
@@ -11,6 +11,7 @@ import GRPC
 import ZcashLightClientKit
 import XCTest
 import NIO
+import NIOTransportServices
 
 enum Environment {
     static let lightwalletdKey = "LIGHTWALLETD_ADDRESS"
@@ -40,8 +41,8 @@ class ChannelProvider {
         let endpoint = LightWalletEndpointBuilder.default
 
         let connectionBuilder = secure ?
-        ClientConnection.usingPlatformAppropriateTLS(for: MultiThreadedEventLoopGroup(numberOfThreads: 1)) :
-        ClientConnection.insecure(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+        ClientConnection.usingPlatformAppropriateTLS(for: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)) :
+        ClientConnection.insecure(group: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default))
 
         let channel = connectionBuilder
             .withKeepalive(


### PR DESCRIPTION
Closes #541 

MultiThreadedEventLoopGroup has been replaced with NIOTSEventLoopGroup. It's recommended by authors of grpc-swift especially for iOS platform and it allows us to set the priority because NIOTSEventLoopGroup is GCD based while MultiThreadedEventLoopGroup is pthread based.

From the authors
```
/// In general, when building applications whose primary purpose is to be deployed on Darwin
/// platforms, the `NIOTSEventLoopGroup` should be preferred over the
/// `MultiThreadedEventLoopGroup`. In particular, on iOS, the `NIOTSEventLoopGroup` is the
/// preferred networking backend.
```

DarkSideTests
<img width="367" alt="Screenshot 2022-09-28 at 9 20 51" src="https://user-images.githubusercontent.com/7198042/192714314-3a94e68e-21e7-4762-a0e6-e2d1a348774a.png">

Kudos to @Chlup for co-working on this one.


This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [x] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [x] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.