### PR TITLE
Use only one stream when processing blocks in parallel

### DIFF
--- a/Sources/ZcashLightClientKit/Block/Processor/CompactBlockScanning.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/CompactBlockScanning.swift
@@ -12,7 +12,7 @@ extension CompactBlockProcessor {
     func compactBlockBatchScanning(range: CompactBlockRange) async throws {
         try Task.checkCancellation()
 
-        let batchSize = UInt32(config.scanningBatchSize)
+        let batchSize = UInt32(processingBatchSize(for: range, network: config.network.networkType))
         
         do {
             if batchSize == 0 {

--- a/Sources/ZcashLightClientKit/Block/Processor/FetchUnspentTxOutputs.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/FetchUnspentTxOutputs.swift
@@ -35,10 +35,11 @@ extension CompactBlockProcessor {
             
             var utxos: [UnspentTransactionOutputEntity] = []
             let stream: AsyncThrowingStream<UnspentTransactionOutputEntity, Error> = downloader.fetchUnspentTransactionOutputs(tAddresses: tAddresses, startHeight: config.walletBirthday)
+
             for try await transaction in stream {
                 utxos.append(transaction)
             }
-            
+
             var refreshed: [UnspentTransactionOutputEntity] = []
             var skipped: [UnspentTransactionOutputEntity] = []
 

--- a/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
+++ b/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
@@ -71,7 +71,7 @@ public enum ZcashSDK {
 
     /// Default size of batches of blocks to request from the compact block service. Which was used both for scanning and downloading.
     /// consider basing your code assumptions on `DefaultDownloadBatch` and `DefaultScanningBatch` instead.
-    @available(*, deprecated, message: "this value is being deprecated in favor of `DefaultDownloadBatch` and `DefaultScanningBatch`")
+    @available(*, deprecated, message: "this value is being deprecated in favor of `DefaultDownloadBatch`")
     public static var DefaultBatchSize = 100
 
     /// Default batch size for downloading blocks for the compact block processor. This value was changed due to
@@ -81,9 +81,6 @@ public enum ZcashSDK {
     
     /// Default number of Tasks running in parallel and downloading block ranges.
     public static var tasksInParallel = 10
-
-    /// Default batch size for scanning blocks for the compact block processor
-    public static var DefaultScanningBatch = 100
 
     /// Default amount of time, in in seconds, to poll for new blocks. Typically, this should be about half the average
     /// block time.

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -148,7 +148,7 @@ class BlockScanTests: XCTestCase {
             walletBirthday: network.constants.saplingActivationHeight,
             network: network
         )
-        processorConfig.scanningBatchSize = 1000
+        processorConfig.downloadBatchSize = 1000
         
         let compactBlockProcessor = CompactBlockProcessor(
             service: service,
@@ -162,11 +162,12 @@ class BlockScanTests: XCTestCase {
         )
         
         do {
-            try await compactBlockProcessor.compactBlockStreamDownload(
-                blockBufferSize: 10,
+            let blocksStream = try await compactBlockProcessor.compactBlocksDownloadStream(
                 startHeight: range.lowerBound,
                 targetHeight: range.upperBound
             )
+            let blocks = try await compactBlockProcessor.readBlocks(from: blocksStream, at: range)
+            try await compactBlockProcessor.storeCompactBlocks(buffer: blocks)
             XCTAssertFalse(Task.isCancelled)
             
             try await compactBlockProcessor.compactBlockValidation()


### PR DESCRIPTION
- It makes sense to have only one downloading stream for blocks even when processing blocks in parallel. Especially on mobile devices we can expect that internet connection won't be super fast.
- And it makes sense to not rely on some magic inside gRPC library and be sure that there always be only one download stream no matter what.
- Disadvantage of this approach is that there is no real parallelisation until we can scan in parallel. With this one stream approach we have multiple tasks but only one runs at the time.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.