### PR TITLE
[#657] Change how blocks are downloaded and processed

### DIFF
--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Send/SendViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Send/SendViewController.swift
@@ -336,17 +336,14 @@ extension SendViewController: UITextViewDelegate {
 extension SDKSynchronizer {
     static func textFor(state: SyncStatus) -> String {
         switch state {
-        case .downloading(let progress):
-            return "Downloading \(progress.progressHeight)/\(progress.targetHeight)"
+        case .syncing(let progress):
+            return "Syncing \(progress.progressHeight)/\(progress.targetHeight)"
 
         case .enhancing(let enhanceProgress):
             return "Enhancing tx \(enhanceProgress.enhancedTransactions) of \(enhanceProgress.totalTransactions)"
 
         case .fetching:
             return "fetching UTXOs"
-
-        case .scanning(let scanProgress):
-            return "Scanning: \(scanProgress.progressHeight)/\(scanProgress.targetHeight)"
 
         case .disconnected:
             return "disconnected 💔"
@@ -359,9 +356,6 @@ extension SDKSynchronizer {
 
         case .unprepared:
             return "Unprepared 😅"
-
-        case .validating:
-            return "Validating"
 
         case .error(let e):
             return "Error: \(e.localizedDescription)"

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
@@ -46,9 +46,6 @@ class SyncBlocksViewController: UIViewController {
             .synchronizerStopped,
             .synchronizerDisconnected,
             .synchronizerSyncing,
-            .synchronizerDownloading,
-            .synchronizerValidating,
-            .synchronizerScanning,
             .synchronizerEnhancing,
             .synchronizerFetching,
             .synchronizerFailed
@@ -112,7 +109,7 @@ class SyncBlocksViewController: UIViewController {
         case let not where not == Notification.Name.synchronizerProgressUpdated:
             guard let progress = notification.userInfo?[SDKSynchronizer.NotificationKeys.progress] as? CompactBlockProgress else { return }
             self.progressBar.progress = progress.progress
-            self.progressLabel.text = "\(Int(floor(progress.progress * 100)))%"
+            self.progressLabel.text = "\(floor(progress.progress * 1000) / 10)%"
         default:
             return
         }
@@ -177,7 +174,7 @@ class SyncBlocksViewController: UIViewController {
 
     func buttonText(for state: SyncStatus) -> String {
         switch state {
-        case .downloading, .scanning, .validating:
+        case .syncing:
             return "Pause"
         case .stopped:
             return "Start"
@@ -194,16 +191,12 @@ class SyncBlocksViewController: UIViewController {
 
     func textFor(state: SyncStatus) -> String {
         switch state {
-        case .downloading:
-            return "Downloading ⛓"
+        case .syncing:
+            return "Syncing 🤖"
         case .error:
             return "error 💔"
-        case .scanning:
-            return "Scanning Blocks 🤖"
         case .stopped:
             return "Stopped 🚫"
-        case .validating:
-            return "Validating chain 🕵️‍♀️"
         case .synced:
             return "Synced 😎"
         case .enhancing:

--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zcash-hackworks/zcash-light-client-ffi",
       "state" : {
-        "revision" : "fad9802b907822d5a1877584c91f3786824521b7",
-        "version" : "0.1.0"
+        "revision" : "b6013b8b313523b2c72ce62dbdc17f6ffad3a500",
+        "version" : "0.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.8.0"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.14.1"),
-        .package(name:"libzcashlc", url: "https://github.com/zcash-hackworks/zcash-light-client-ffi", from: "0.1.0")
+        .package(name:"libzcashlc", url: "https://github.com/zcash-hackworks/zcash-light-client-ffi", from: "0.1.1")
     ],
     targets: [
         .target(

--- a/Sources/ZcashLightClientKit/Block/Processor/CompactBlockDownload.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/CompactBlockDownload.swift
@@ -9,59 +9,120 @@
 import Foundation
 
 extension CompactBlockProcessor {
-    func compactBlockStreamDownload(
-        blockBufferSize: Int,
+
+    class BlocksDownloadStream {
+        let stream: AsyncThrowingStream<ZcashCompactBlock, Error>
+        var iterator: AsyncThrowingStream<ZcashCompactBlock, Error>.Iterator
+
+        init(stream: AsyncThrowingStream<ZcashCompactBlock, Error>) {
+            self.stream = stream
+            self.iterator = stream.makeAsyncIterator()
+        }
+
+        func nextBlock() async throws -> ZcashCompactBlock? {
+            return try await iterator.next()
+        }
+    }
+
+    func downloadAndScanBlocks(at range: CompactBlockRange, totalProgressRange: CompactBlockRange) async throws {
+        let downloadStream = try await compactBlocksDownloadStream(
+            startHeight: range.lowerBound,
+            targetHeight: range.upperBound
+        )
+
+        // Divide `range` by `batchSize` and compute how many time do we need to run to download and scan all the blocks.
+        // +1 must be done here becase `range` is closed range. So even if upperBound and lowerBound are same there is one block to sync.
+        let blocksCountToSync = (range.upperBound - range.lowerBound) + 1
+        var loopsCount = blocksCountToSync / batchSize
+        if blocksCountToSync % batchSize != 0 {
+            loopsCount += 1
+        }
+
+        for i in 0..<loopsCount {
+            let processingRange = computeSingleLoopDownloadRange(fullRange: range, loopCounter: i, batchSize: batchSize)
+
+            LoggerProxy.debug("Sync loop #\(i+1) range: \(processingRange.lowerBound)...\(processingRange.upperBound)")
+
+            try await downloadAndStoreBlocks(using: downloadStream, at: processingRange, maxBlockBufferSize: config.downloadBufferSize)
+            try await compactBlockValidation()
+            try await compactBlockBatchScanning(range: processingRange)
+            try await removeCacheDB()
+
+            let progress = BlockProgress(
+                startHeight: totalProgressRange.lowerBound,
+                targetHeight: totalProgressRange.upperBound,
+                progressHeight: processingRange.upperBound
+            )
+            notifyProgress(.syncing(progress))
+        }
+    }
+
+    /*
+     Here range for one batch is computed. For example if we want to sync blocks 0...1000 with batchSize 100 we want to generage blocks like
+     this:
+     0...99
+     100...199
+     200...299
+     300...399
+     ...
+     900...999
+     1000...1000
+     */
+    func computeSingleLoopDownloadRange(fullRange: CompactBlockRange, loopCounter: Int, batchSize: BlockHeight) -> CompactBlockRange {
+        let lowerBound = fullRange.lowerBound + (loopCounter * batchSize)
+        let upperBound = min(fullRange.lowerBound + ((loopCounter+1) * batchSize) - 1, fullRange.upperBound)
+        return lowerBound...upperBound
+    }
+
+    func compactBlocksDownloadStream(
         startHeight: BlockHeight? = nil,
         targetHeight: BlockHeight? = nil
-    ) async throws {
+    ) async throws -> BlocksDownloadStream {
         try Task.checkCancellation()
-        
-        state = .downloading
-        
-        var buffer: [ZcashCompactBlock] = []
-        var targetHeightInternal: BlockHeight?
-        
-        do {
-            targetHeightInternal = targetHeight
-            if targetHeight == nil {
-                targetHeightInternal = try await service.latestBlockHeightAsync()
-            }
-            guard let latestHeight = targetHeightInternal else {
-                throw LightWalletServiceError.generalError(message: "missing target height on compactBlockStreamDownload")
-            }
-            try Task.checkCancellation()
-            let latestDownloaded = try storage.latestBlockHeight()
-            let startHeight = max(startHeight ?? BlockHeight.empty(), latestDownloaded)
 
-            let stream = service.blockStream(
-                startHeight: startHeight,
-                endHeight: latestHeight
-            )
-            
-            for try await zcashCompactBlock in stream {
-                try Task.checkCancellation()
-                buffer.append(zcashCompactBlock)
-                if buffer.count >= blockBufferSize {
-                    try await storage.write(blocks: buffer)
-                    await blocksBufferWritten(buffer)
-                    buffer.removeAll(keepingCapacity: true)
-                }
-                
-                let progress = BlockProgress(
-                    startHeight: startHeight,
-                    targetHeight: latestHeight,
-                    progressHeight: zcashCompactBlock.height
-                )
-                notifyProgress(.download(progress))
-            }
-            try await storage.write(blocks: buffer)
-            await blocksBufferWritten(buffer)
-            buffer.removeAll(keepingCapacity: true)
-        } catch {
-            guard let err = error as? LightWalletServiceError, case .userCancelled = err else {
-                throw error
+        var targetHeightInternal: BlockHeight? = targetHeight
+        if targetHeight == nil {
+            targetHeightInternal = try await service.latestBlockHeightAsync()
+        }
+        guard let latestHeight = targetHeightInternal else {
+            throw LightWalletServiceError.generalError(message: "missing target height on compactBlockStreamDownload")
+        }
+        try Task.checkCancellation()
+        let latestDownloaded = try await storage.latestHeightAsync()
+        let startHeight = max(startHeight ?? BlockHeight.empty(), latestDownloaded)
+
+        let stream = service.blockStream(
+            startHeight: startHeight,
+            endHeight: latestHeight
+        )
+
+        return BlocksDownloadStream(stream: stream)
+    }
+
+    func downloadAndStoreBlocks(using stream: BlocksDownloadStream, at range: CompactBlockRange, maxBlockBufferSize: Int) async throws {
+        var buffer: [ZcashCompactBlock] = []
+        LoggerProxy.debug("Downloading blocks in range: \(range.lowerBound)...\(range.upperBound)")
+        for _ in stride(from: range.lowerBound, to: range.upperBound + 1, by: 1) {
+            try Task.checkCancellation()
+            guard let block = try await stream.nextBlock() else { break }
+
+            buffer.append(block)
+            if buffer.count >= maxBlockBufferSize {
+                try await storage.write(blocks: buffer)
+                await blocksBufferWritten(buffer)
+                buffer.removeAll(keepingCapacity: true)
             }
         }
+
+        try await storage.write(blocks: buffer)
+        await blocksBufferWritten(buffer)
+    }
+
+    private func removeCacheDB() async throws {
+        storage.closeDBConnection()
+        try FileManager.default.removeItem(at: config.cacheDb)
+        try storage.createTable()
+        LoggerProxy.info("Cache removed")
     }
 
     private func blocksBufferWritten(_ buffer: [ZcashCompactBlock]) async {

--- a/Sources/ZcashLightClientKit/Block/Processor/CompactBlockValidationInformation.swift
+++ b/Sources/ZcashLightClientKit/Block/Processor/CompactBlockValidationInformation.swift
@@ -17,8 +17,6 @@ extension CompactBlockProcessor {
     func compactBlockValidation() async throws {
         try Task.checkCancellation()
         
-        state = .validating
-
         let result = rustBackend.validateCombinedChain(dbCache: config.cacheDb, dbData: config.dataDb, networkType: config.network.networkType)
         
         do {

--- a/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
+++ b/Sources/ZcashLightClientKit/Constants/ZcashSDK.swift
@@ -82,10 +82,10 @@ public enum ZcashSDK {
     @available(*, deprecated, message: "this value is being deprecated in favor of `DefaultDownloadBatch` and `DefaultScanningBatch`")
     public static var DefaultBatchSize = 100
 
-    /// Default batch size for downloading blocks for the compact block processor. This value was changed due to
-    /// full blocks causing block download memory usage significantly and also timeouts on grpc calls.
-    /// this value is subject to change in the future.
-    public static var DefaultDownloadBatch = 10
+    /// Default batch size for downloading blocks for the compact block processor. Be careful with this number. This amount of blocks is held in
+    /// memory at some point of the sync process.
+    /// This values can't be smaller than `DefaultScanningBatch`. Otherwise bad things will happen.
+    public static var DefaultDownloadBatch = 100
 
     /// Default batch size for scanning blocks for the compact block processor
     public static var DefaultScanningBatch = 100

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -202,17 +202,7 @@ public enum SyncStatus: Equatable {
     /// taking other maintenance steps that need to occur after an upgrade.
     case unprepared
 
-    /// Indicates that this Synchronizer is actively downloading new blocks from the server.
-    case downloading(_ status: BlockProgress)
-
-    /// Indicates that this Synchronizer is actively validating new blocks that were downloaded
-    /// from the server. Blocks need to be verified before they are scanned. This confirms that
-    /// each block is chain-sequential, thereby detecting missing blocks and reorgs.
-    case validating
-
-    /// Indicates that this Synchronizer is actively scanning new valid blocks that were
-    /// downloaded from the server.
-    case scanning(_ progress: BlockProgress)
+    case syncing(_ progress: BlockProgress)
 
     /// Indicates that this Synchronizer is actively enhancing newly scanned blocks
     /// with additional transaction details, fetched from the server.
@@ -236,7 +226,7 @@ public enum SyncStatus: Equatable {
     
     public var isSyncing: Bool {
         switch self {
-        case .downloading, .validating, .scanning, .enhancing, .fetching:
+        case .syncing, .enhancing, .fetching:
             return true
         default:
             return false
@@ -285,20 +275,8 @@ extension SyncStatus {
             } else {
                 return false
             }
-        case .downloading:
-            if case .downloading = rhs {
-                return true
-            } else {
-                return false
-            }
-        case .validating:
-            if case .validating = rhs {
-                return true
-            } else {
-                return false
-            }
-        case .scanning:
-            if case .scanning = rhs {
+        case .syncing:
+            if case .syncing = rhs {
                 return true
             } else {
                 return false
@@ -340,12 +318,8 @@ extension SyncStatus {
 extension SyncStatus {
     init(_ blockProcessorProgress: CompactBlockProgress) {
         switch blockProcessorProgress {
-        case .download(let progressReport):
-            self = SyncStatus.downloading(progressReport)
-        case .validate:
-            self = .validating
-        case .scan(let progressReport):
-            self = .scanning(progressReport)
+        case .syncing(let progressReport):
+            self = .syncing(progressReport)
         case .enhance(let enhancingReport):
             self = .enhancing(enhancingReport)
         case .fetch:

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -34,15 +34,6 @@ public extension Notification.Name {
     /// Posted when the synchronizer starts syncing
     static let synchronizerSyncing = Notification.Name("SDKSyncronizerSyncing")
 
-    /// Posted when synchronizer starts downloading blocks
-    static let synchronizerDownloading = Notification.Name("SDKSyncronizerDownloading")
-
-    /// Posted when synchronizer starts validating blocks
-    static let synchronizerValidating = Notification.Name("SDKSyncronizerValidating")
-
-    /// Posted when synchronizer starts scanning blocks
-    static let synchronizerScanning = Notification.Name("SDKSyncronizerScanning")
-
     /// Posted when the synchronizer starts Enhancing
     static let synchronizerEnhancing = Notification.Name("SDKSyncronizerEnhancing")
 
@@ -186,7 +177,7 @@ public class SDKSynchronizer: Synchronizer {
         case .unprepared:
             throw SynchronizerError.notPrepared
 
-        case .downloading, .validating, .scanning, .enhancing, .fetching:
+        case .syncing, .enhancing, .fetching:
             LoggerProxy.warn("warning: synchronizer started when already started")
             return
 
@@ -233,22 +224,8 @@ public class SDKSynchronizer: Synchronizer {
 
         center.addObserver(
             self,
-            selector: #selector(processorStartedDownloading(_:)),
-            name: Notification.Name.blockProcessorStartedDownloading,
-            object: processor
-        )
-
-        center.addObserver(
-            self,
-            selector: #selector(processorStartedValidating(_:)),
-            name: Notification.Name.blockProcessorStartedValidating,
-            object: processor
-        )
-
-        center.addObserver(
-            self,
-            selector: #selector(processorStartedScanning(_:)),
-            name: Notification.Name.blockProcessorStartedScanning,
+            selector: #selector(processorStartedSyncing(_:)),
+            name: Notification.Name.blockProcessorStartedSyncing,
             object: processor
         )
 
@@ -392,29 +369,14 @@ public class SDKSynchronizer: Synchronizer {
         self.notify(progress: progress)
     }
 
-    @objc func processorStartedDownloading(_ notification: Notification) {
+    @objc func processorStartedSyncing(_ notification: Notification) {
         statusUpdateLock.lock()
         defer { statusUpdateLock.unlock() }
 
-        guard status != .downloading(.nullProgress) else { return }
-        status = .downloading(.nullProgress)
+        guard status != .syncing(.nullProgress) else { return }
+        status = .syncing(.nullProgress)
     }
 
-    @objc func processorStartedValidating(_ notification: Notification) {
-        statusUpdateLock.lock()
-        defer { statusUpdateLock.unlock() }
-
-        guard status != .validating else { return }
-        status = .validating
-    }
-
-    @objc func processorStartedScanning(_ notification: Notification) {
-        statusUpdateLock.lock()
-        defer { statusUpdateLock.unlock() }
-
-        guard status != .scanning(.nullProgress) else { return }
-        status = .scanning(.nullProgress)
-    }
     @objc func processorStartedEnhancing(_ notification: Notification) {
         statusUpdateLock.lock()
         defer { statusUpdateLock.unlock() }
@@ -739,12 +701,8 @@ public class SDKSynchronizer: Synchronizer {
             }
         case .unprepared:
             break
-        case .downloading:
-            NotificationSender.default.post(name: Notification.Name.synchronizerDownloading, object: self)
-        case .validating:
-            NotificationSender.default.post(name: Notification.Name.synchronizerValidating, object: self)
-        case .scanning:
-            NotificationSender.default.post(name: Notification.Name.synchronizerScanning, object: self)
+        case .syncing:
+            NotificationSender.default.post(name: Notification.Name.synchronizerSyncing, object: self)
         case .enhancing:
             NotificationSender.default.post(name: Notification.Name.synchronizerEnhancing, object: self)
         case .fetching:

--- a/Tests/DarksideTests/ShieldFundsTests.swift
+++ b/Tests/DarksideTests/ShieldFundsTests.swift
@@ -176,14 +176,14 @@ class ShieldFundsTests: XCTestCase {
         let tFundsDetectedBalance = try await coordinator.synchronizer.getTransparentBalance(accountIndex: 0)
 
         XCTAssertEqual(tFundsDetectedBalance.total, Zatoshi(10000))
-        XCTAssertEqual(tFundsDetectedBalance.verified, Zatoshi(10000)) //FIXME: this should be zero
+        XCTAssertEqual(tFundsDetectedBalance.verified, .zero)
 
         let tFundsConfirmationSyncExpectation = XCTestExpectation(description: "t funds confirmation")
 
         shouldContinue = false
 
         // 7. stage ten blocks and confirm the transparent funds at `utxoHeight + 10`
-        try coordinator.applyStaged(blockheight: utxoHeight + 20) // FIXME: funds are confirmed at 20 blocks
+        try coordinator.applyStaged(blockheight: utxoHeight + 10)
 
         sleep(2)
 

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -23,11 +23,9 @@ class TransactionEnhancementTests: XCTestCase {
     var processor: CompactBlockProcessor!
     var darksideWalletService: DarksideWalletService!
     var downloader: CompactBlockDownloader!
-    var downloadStartedExpect: XCTestExpectation!
+    var syncStartedExpect: XCTestExpectation!
     var updatedNotificationExpectation: XCTestExpectation!
     var stopNotificationExpectation: XCTestExpectation!
-    var startedScanningNotificationExpectation: XCTestExpectation!
-    var startedValidatingNotificationExpectation: XCTestExpectation!
     var idleNotificationExpectation: XCTestExpectation!
     var reorgNotificationExpectation: XCTestExpectation!
     var afterReorgIdleNotification: XCTestExpectation!
@@ -40,15 +38,9 @@ class TransactionEnhancementTests: XCTestCase {
 
         logger = SampleLogger(logLevel: .debug)
         
-        downloadStartedExpect = XCTestExpectation(description: "\(self.description) downloadStartedExpect")
+        syncStartedExpect = XCTestExpectation(description: "\(self.description) syncStartedExpect")
         stopNotificationExpectation = XCTestExpectation(description: "\(self.description) stopNotificationExpectation")
         updatedNotificationExpectation = XCTestExpectation(description: "\(self.description) updatedNotificationExpectation")
-        startedValidatingNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedValidatingNotificationExpectation"
-        )
-        startedScanningNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedScanningNotificationExpectation"
-        )
         idleNotificationExpectation = XCTestExpectation(description: "\(self.description) idleNotificationExpectation")
         afterReorgIdleNotification = XCTestExpectation(description: "\(self.description) afterReorgIdleNotification")
         reorgNotificationExpectation = XCTestExpectation(description: "\(self.description) reorgNotificationExpectation")
@@ -126,11 +118,9 @@ class TransactionEnhancementTests: XCTestCase {
         try super.tearDownWithError()
         try? FileManager.default.removeItem(at: processorConfig.cacheDb)
         try? FileManager.default.removeItem(at: processorConfig.dataDb)
-        downloadStartedExpect.unsubscribeFromNotifications()
+        syncStartedExpect.unsubscribeFromNotifications()
         stopNotificationExpectation.unsubscribeFromNotifications()
         updatedNotificationExpectation.unsubscribeFromNotifications()
-        startedScanningNotificationExpectation.unsubscribeFromNotifications()
-        startedValidatingNotificationExpectation.unsubscribeFromNotifications()
         idleNotificationExpectation.unsubscribeFromNotifications()
         reorgNotificationExpectation.unsubscribeFromNotifications()
         afterReorgIdleNotification.unsubscribeFromNotifications()
@@ -141,11 +131,9 @@ class TransactionEnhancementTests: XCTestCase {
         XCTAssertNotNil(processor)
         
         // Subscribe to notifications
-        downloadStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedDownloading, object: processor)
+        syncStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedSyncing, object: processor)
         stopNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStopped, object: processor)
         updatedNotificationExpectation.subscribe(to: Notification.Name.blockProcessorUpdated, object: processor)
-        startedValidatingNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedValidating, object: processor)
-        startedScanningNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedScanning, object: processor)
 
         txFoundNotificationExpectation.subscribe(to: .blockProcessorFoundTransactions, object: processor)
         idleNotificationExpectation.subscribe(to: .blockProcessorIdle, object: processor)
@@ -188,9 +176,7 @@ class TransactionEnhancementTests: XCTestCase {
 
         wait(
             for: [
-                downloadStartedExpect,
-                startedValidatingNotificationExpectation,
-                startedScanningNotificationExpectation,
+                syncStartedExpect,
                 txFoundNotificationExpectation,
                 idleNotificationExpectation
             ],

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -183,11 +183,12 @@ class BlockScanTests: XCTestCase {
         )
         
         do {
-            try await compactBlockProcessor.compactBlockStreamDownload(
-                blockBufferSize: 10,
+            let downloadStream = try await compactBlockProcessor.compactBlocksDownloadStream(
                 startHeight: range.lowerBound,
                 targetHeight: range.upperBound
             )
+
+            try await compactBlockProcessor.downloadAndStoreBlocks(using: downloadStream, at: range, maxBlockBufferSize: 10)
             XCTAssertFalse(Task.isCancelled)
             
             try await compactBlockProcessor.compactBlockValidation()

--- a/Tests/NetworkTests/CompactBlockProcessorTests.swift
+++ b/Tests/NetworkTests/CompactBlockProcessorTests.swift
@@ -17,11 +17,9 @@ class CompactBlockProcessorTests: XCTestCase {
         walletBirthday: ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight
     )
     var processor: CompactBlockProcessor!
-    var downloadStartedExpect: XCTestExpectation!
+    var syncStartedExpect: XCTestExpectation!
     var updatedNotificationExpectation: XCTestExpectation!
     var stopNotificationExpectation: XCTestExpectation!
-    var startedScanningNotificationExpectation: XCTestExpectation!
-    var startedValidatingNotificationExpectation: XCTestExpectation!
     var idleNotificationExpectation: XCTestExpectation!
     let network = ZcashNetworkBuilder.network(for: .testnet)
     let mockLatestHeight = ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight + 2000
@@ -62,15 +60,9 @@ class CompactBlockProcessorTests: XCTestCase {
             return
         }
         
-        downloadStartedExpect = XCTestExpectation(description: "\(self.description) downloadStartedExpect")
+        syncStartedExpect = XCTestExpectation(description: "\(self.description) syncStartedExpect")
         stopNotificationExpectation = XCTestExpectation(description: "\(self.description) stopNotificationExpectation")
         updatedNotificationExpectation = XCTestExpectation(description: "\(self.description) updatedNotificationExpectation")
-        startedValidatingNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedValidatingNotificationExpectation"
-        )
-        startedScanningNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedScanningNotificationExpectation"
-        )
         idleNotificationExpectation = XCTestExpectation(description: "\(self.description) idleNotificationExpectation")
         NotificationCenter.default.addObserver(
             self,
@@ -84,11 +76,9 @@ class CompactBlockProcessorTests: XCTestCase {
         super.tearDown()
         try! FileManager.default.removeItem(at: processorConfig.cacheDb)
         try? FileManager.default.removeItem(at: processorConfig.dataDb)
-        downloadStartedExpect.unsubscribeFromNotifications()
+        syncStartedExpect.unsubscribeFromNotifications()
         stopNotificationExpectation.unsubscribeFromNotifications()
         updatedNotificationExpectation.unsubscribeFromNotifications()
-        startedScanningNotificationExpectation.unsubscribeFromNotifications()
-        startedValidatingNotificationExpectation.unsubscribeFromNotifications()
         idleNotificationExpectation.unsubscribeFromNotifications()
         NotificationCenter.default.removeObserver(self)
     }
@@ -106,11 +96,9 @@ class CompactBlockProcessorTests: XCTestCase {
         XCTAssertNotNil(processor)
         
         // Subscribe to notifications
-        downloadStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedDownloading, object: processor)
+        syncStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedSyncing, object: processor)
         stopNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStopped, object: processor)
         updatedNotificationExpectation.subscribe(to: Notification.Name.blockProcessorUpdated, object: processor)
-        startedValidatingNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedValidating, object: processor)
-        startedScanningNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedScanning, object: processor)
         idleNotificationExpectation.subscribe(to: Notification.Name.blockProcessorIdle, object: processor)
         
         await processor.start()
@@ -121,9 +109,7 @@ class CompactBlockProcessorTests: XCTestCase {
    
         wait(
             for: [
-                downloadStartedExpect,
-                startedValidatingNotificationExpectation,
-                startedScanningNotificationExpectation,
+                syncStartedExpect,
                 idleNotificationExpectation
             ],
             timeout: 30,
@@ -154,8 +140,8 @@ class CompactBlockProcessorTests: XCTestCase {
         
         var expectedSyncRanges = SyncRanges(
             latestBlockHeight: latestBlockchainHeight,
-            downloadRange: latestDownloadedHeight...latestBlockchainHeight,
-            scanRange: processorConfig.walletBirthday...latestBlockchainHeight,
+            downloadedButUnscannedRange: 1...latestDownloadedHeight,
+            downloadAndScanRange: latestDownloadedHeight...latestBlockchainHeight,
             enhanceRange: processorConfig.walletBirthday...latestBlockchainHeight,
             fetchUTXORange: processorConfig.walletBirthday...latestBlockchainHeight
         )
@@ -181,8 +167,8 @@ class CompactBlockProcessorTests: XCTestCase {
 
         expectedSyncRanges = SyncRanges(
             latestBlockHeight: latestBlockchainHeight,
-            downloadRange: latestDownloadedHeight+1...latestBlockchainHeight,
-            scanRange: processorConfig.walletBirthday...latestBlockchainHeight,
+            downloadedButUnscannedRange: 1...latestDownloadedHeight,
+            downloadAndScanRange: latestDownloadedHeight+1...latestBlockchainHeight,
             enhanceRange: processorConfig.walletBirthday...latestBlockchainHeight,
             fetchUTXORange: processorConfig.walletBirthday...latestBlockchainHeight
         )
@@ -209,8 +195,8 @@ class CompactBlockProcessorTests: XCTestCase {
 
         expectedSyncRanges = SyncRanges(
             latestBlockHeight: latestBlockchainHeight,
-            downloadRange: latestDownloadedHeight+1...latestBlockchainHeight,
-            scanRange: processorConfig.walletBirthday...latestBlockchainHeight,
+            downloadedButUnscannedRange: 1...latestDownloadedHeight,
+            downloadAndScanRange: latestDownloadedHeight+1...latestBlockchainHeight,
             enhanceRange: processorConfig.walletBirthday...latestBlockchainHeight,
             fetchUTXORange: processorConfig.walletBirthday...latestBlockchainHeight
         )

--- a/Tests/NetworkTests/CompactBlockReorgTests.swift
+++ b/Tests/NetworkTests/CompactBlockReorgTests.swift
@@ -17,11 +17,9 @@ class CompactBlockReorgTests: XCTestCase {
         walletBirthday: ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight
     )
     var processor: CompactBlockProcessor!
-    var downloadStartedExpect: XCTestExpectation!
+    var syncStartedExpect: XCTestExpectation!
     var updatedNotificationExpectation: XCTestExpectation!
     var stopNotificationExpectation: XCTestExpectation!
-    var startedScanningNotificationExpectation: XCTestExpectation!
-    var startedValidatingNotificationExpectation: XCTestExpectation!
     var idleNotificationExpectation: XCTestExpectation!
     var reorgNotificationExpectation: XCTestExpectation!
     let network = ZcashNetworkBuilder.network(for: .testnet)
@@ -67,15 +65,9 @@ class CompactBlockReorgTests: XCTestCase {
             config: processorConfig
         )
         
-        downloadStartedExpect = XCTestExpectation(description: "\(self.description) downloadStartedExpect")
+        syncStartedExpect = XCTestExpectation(description: "\(self.description) syncStartedExpect")
         stopNotificationExpectation = XCTestExpectation(description: "\(self.description) stopNotificationExpectation")
         updatedNotificationExpectation = XCTestExpectation(description: "\(self.description) updatedNotificationExpectation")
-        startedValidatingNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedValidatingNotificationExpectation"
-        )
-        startedScanningNotificationExpectation = XCTestExpectation(
-            description: "\(self.description) startedScanningNotificationExpectation"
-        )
         idleNotificationExpectation = XCTestExpectation(description: "\(self.description) idleNotificationExpectation")
         reorgNotificationExpectation = XCTestExpectation(description: "\(self.description) reorgNotificationExpectation")
         
@@ -98,11 +90,9 @@ class CompactBlockReorgTests: XCTestCase {
         super.tearDown()
         try! FileManager.default.removeItem(at: processorConfig.cacheDb)
         try? FileManager.default.removeItem(at: processorConfig.dataDb)
-        downloadStartedExpect.unsubscribeFromNotifications()
+        syncStartedExpect.unsubscribeFromNotifications()
         stopNotificationExpectation.unsubscribeFromNotifications()
         updatedNotificationExpectation.unsubscribeFromNotifications()
-        startedScanningNotificationExpectation.unsubscribeFromNotifications()
-        startedValidatingNotificationExpectation.unsubscribeFromNotifications()
         idleNotificationExpectation.unsubscribeFromNotifications()
         reorgNotificationExpectation.unsubscribeFromNotifications()
         NotificationCenter.default.removeObserver(self)
@@ -134,11 +124,9 @@ class CompactBlockReorgTests: XCTestCase {
         XCTAssertNotNil(processor)
         
         // Subscribe to notifications
-        downloadStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedDownloading, object: processor)
+        syncStartedExpect.subscribe(to: Notification.Name.blockProcessorStartedSyncing, object: processor)
         stopNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStopped, object: processor)
         updatedNotificationExpectation.subscribe(to: Notification.Name.blockProcessorUpdated, object: processor)
-        startedValidatingNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedValidating, object: processor)
-        startedScanningNotificationExpectation.subscribe(to: Notification.Name.blockProcessorStartedScanning, object: processor)
         idleNotificationExpectation.subscribe(to: Notification.Name.blockProcessorFinished, object: processor)
         reorgNotificationExpectation.subscribe(to: Notification.Name.blockProcessorHandledReOrg, object: processor)
 
@@ -150,9 +138,7 @@ class CompactBlockReorgTests: XCTestCase {
 
         wait(
             for: [
-                downloadStartedExpect,
-                startedValidatingNotificationExpectation,
-                startedScanningNotificationExpectation,
+                syncStartedExpect,
                 reorgNotificationExpectation,
                 idleNotificationExpectation
             ],

--- a/Tests/OfflineTests/BlockBatchValidationTests.swift
+++ b/Tests/OfflineTests/BlockBatchValidationTests.swift
@@ -333,8 +333,8 @@ class BlockBatchValidationTests: XCTestCase {
 
         let ranges = SyncRanges(
             latestBlockHeight: expectedLatestHeight,
-            downloadRange: expectedStoreLatestHeight+1...expectedLatestHeight,
-            scanRange: expectedStoreLatestHeight+1...expectedLatestHeight,
+            downloadedButUnscannedRange: nil,
+            downloadAndScanRange: expectedStoreLatestHeight+1...expectedLatestHeight,
             enhanceRange: walletBirthday...expectedLatestHeight,
             fetchUTXORange: walletBirthday...expectedLatestHeight
         )

--- a/Tests/OfflineTests/CompactBlockProcessorOfflineTests.swift
+++ b/Tests/OfflineTests/CompactBlockProcessorOfflineTests.swift
@@ -1,0 +1,38 @@
+//
+//  CompactBlockProcessorOfflineTests.swift
+//  
+//
+//  Created by Michal Fousek on 15.12.2022.
+//
+
+
+import XCTest
+@testable import TestUtils
+@testable import ZcashLightClientKit
+
+class CompactBlockProcessorOfflineTests: XCTestCase {
+    func testComputeProcessingRangeForSingleLoop() async throws {
+        let processorConfig = CompactBlockProcessor.Configuration.standard(
+            for: ZcashNetworkBuilder.network(for: .testnet),
+            walletBirthday: ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight
+        )
+
+        let service = MockLightWalletService(
+            latestBlockHeight: 690000,
+            service: LightWalletGRPCService(endpoint: LightWalletEndpointBuilder.eccTestnet)
+        )
+        let storage = CompactBlockStorage.init(connectionProvider: SimpleConnectionProvider(path: processorConfig.cacheDb.absoluteString))
+        let processor = CompactBlockProcessor(service: service, storage: storage, backend: ZcashRustBackend.self, config: processorConfig)
+
+        let fullRange = 0...1000
+
+        var range = await processor.computeSingleLoopDownloadRange(fullRange: fullRange, loopCounter: 0, batchSize: 100)
+        XCTAssertEqual(range, 0...99)
+
+        range = await processor.computeSingleLoopDownloadRange(fullRange: fullRange, loopCounter: 5, batchSize: 100)
+        XCTAssertEqual(range, 500...599)
+
+        range = await processor.computeSingleLoopDownloadRange(fullRange: fullRange, loopCounter: 10, batchSize: 100)
+        XCTAssertEqual(range, 1000...1000)
+    }
+}

--- a/Tests/OfflineTests/InternalSyncProgressTests.swift
+++ b/Tests/OfflineTests/InternalSyncProgressTests.swift
@@ -50,14 +50,14 @@ class InternalSyncProgressTests: XCTestCase {
 
         let nextState = try await internalSyncProgress.computeNextState(
             latestBlockHeight: latestHeight,
-            latestScannedHeight: 630000,
+            latestScannedHeight: 620000,
             walletBirthday: 600000
         )
 
         switch nextState {
         case let .processNewBlocks(ranges):
-            XCTAssertEqual(ranges.downloadRange, 630001...640000)
-            XCTAssertEqual(ranges.scanRange, 630001...640000)
+            XCTAssertEqual(ranges.downloadedButUnscannedRange, 620001...630000)
+            XCTAssertEqual(ranges.downloadAndScanRange, 630001...640000)
             XCTAssertEqual(ranges.enhanceRange, 630001...640000)
             XCTAssertEqual(ranges.fetchUTXORange, 630001...640000)
 

--- a/Tests/TestUtils/FakeStorage.swift
+++ b/Tests/TestUtils/FakeStorage.swift
@@ -26,8 +26,8 @@ class ZcashConsoleFakeStorage: CompactBlockRepository {
         return self.latestBlockHeight
     }
 
-    func latestBlock() throws -> ZcashLightClientKit.ZcashCompactBlock {
-        return ZcashCompactBlock(height: latestBlockHeight, data: Data())
+    func latestBlocks(count: Int) throws -> [ZcashLightClientKit.ZcashCompactBlock] {
+        return (0..<count).map { ZcashCompactBlock(height: latestBlockHeight - $0, data: Data()) }
     }
 
     func rewind(to height: BlockHeight) throws {


### PR DESCRIPTION
Closes #657

- Now SDK downloads N downloads and scan those. And repeat until sync is done. This safes lot of space of disk used to store downloaded blocks.
- Most changes are done in `CompactBlockProcessor.processNewBlocks`.
- `SyncRanges` structure is changed a bit.
- `SyncStatus` is changed. SDK now report that it's syncing with progress. It doesn't report each phase of the sync process separately. Also appropriate notifications were updated.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.