### PR TITLE
[#764] Stop using Notifications inside the SDK

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,7 @@ disabled_rules:
   - nesting # allow for types to be nested, common pattern in Swift
   - multiple_closures_with_trailing_closure 
   - generic_type_name # allow for arbitrarily long generic type names
+  - redundant_void_return
 
 opt_in_rules:
   - mark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Unreleased
+- [#764] Refactor communication between components inside th SDK
+
+    This is mostly an internal change. A consequence of this change is that all the notifications
+delivered via `NotificationCenter` with the prefix `blockProcessor` are now gone. If affected
+notifications were used in your code use notifications with the prefix `synchronizer` now. 
+These notifications are defined in `SDKSynchronizer.swift`.
+
 - [#759] Remove Jazz-generated HTML docs
 
-We remove these documents since they are outdated and we rely on the docs in the 
+    We remove these documents since they are outdated and we rely on the docs in the 
 code itself.
 
 - [#726] Modularize GRPC layer
+
     This is mostly internal change. `LightWalletService` is no longer public. If it
 is used in your code replace it by using `SDKSynchronizer` API.
 

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
@@ -72,7 +72,7 @@ class SyncBlocksViewController: UIViewController {
                 .store(in: &notificationCancellables)
         }
 
-        NotificationCenter.default.publisher(for: .blockProcessorStartedEnhancing, object: nil)
+        NotificationCenter.default.publisher(for: .synchronizerEnhancing, object: nil)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.accumulateMetrics()
@@ -82,7 +82,7 @@ class SyncBlocksViewController: UIViewController {
             }
             .store(in: &notificationCancellables)
 
-        NotificationCenter.default.publisher(for: .blockProcessorUpdated, object: nil)
+        NotificationCenter.default.publisher(for: .synchronizerProgressUpdated, object: nil)
             .throttle(for: 5, scheduler: DispatchQueue.main, latest: true)
             .receive(on: DispatchQueue.main)
             .map { [weak self] _ -> SDKMetrics.BlockMetricReport? in
@@ -94,7 +94,7 @@ class SyncBlocksViewController: UIViewController {
             }
             .store(in: &notificationCancellables)
 
-        NotificationCenter.default.publisher(for: .blockProcessorFinished, object: nil)
+        NotificationCenter.default.publisher(for: .synchronizerSynced, object: nil)
             .receive(on: DispatchQueue.main)
             .delay(for: 0.5, scheduler: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Sources/ZcashLightClientKit/Block/FilesystemStorage/FSCompactBlockRepository.swift
+++ b/Sources/ZcashLightClientKit/Block/FilesystemStorage/FSCompactBlockRepository.swift
@@ -79,7 +79,7 @@ extension FSCompactBlockRepository: CompactBlockRepository {
                 do {
                     try self.fileWriter.writeToURL(block.data, blockURL)
                 } catch {
-                    LoggerProxy.error("Failed to write block: \(block.height) to path: \(blockURL.path).")
+                    LoggerProxy.error("Failed to write block: \(block.height) to path: \(blockURL.path) with error: \(error)")
                     throw CompactBlockRepositoryError.failedToWriteBlock(block)
                 }
 

--- a/Sources/ZcashLightClientKit/DAO/NotesDao.swift
+++ b/Sources/ZcashLightClientKit/DAO/NotesDao.swift
@@ -141,7 +141,7 @@ class SentNotesSQLDAO: SentNotesRepository {
             try row.decode()
         }) else { return [] }
 
-        return rows.compactMap { (sentNote) -> TransactionRecipient? in
+        return rows.compactMap { sentNote -> TransactionRecipient? in
             if sentNote.toAccount == nil {
                 guard
                     let toAddress = sentNote.toAddress,

--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -259,11 +259,11 @@ public class Initializer {
             endpoint: endpoint,
             connectionStateChange: { oldState, newState in
                 NotificationSender.default.post(
-                    name: .blockProcessorConnectivityStateChanged,
-                    object: nil,
+                    name: .synchronizerConnectionStateChanged,
+                    object: self,
                     userInfo: [
-                        CompactBlockProcessorNotificationKey.currentConnectivityStatus: newState,
-                        CompactBlockProcessorNotificationKey.previousConnectivityStatus: oldState
+                        SDKSynchronizer.NotificationKeys.previousConnectionState: oldState,
+                        SDKSynchronizer.NotificationKeys.currentConnectionState: newState
                     ]
                 )
             }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -347,4 +347,3 @@ extension SyncStatus {
         }
     }
 }
-

--- a/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
+++ b/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
@@ -25,7 +25,6 @@ class PendingTransactionUpdatesTest: XCTestCase {
     var sentTransactionExpectation = XCTestExpectation(description: "sent")
     var expectedReorgHeight: BlockHeight = 665188
     var expectedRewindHeight: BlockHeight = 665188
-    var reorgExpectation = XCTestExpectation(description: "reorg")
     let branchID = "2bb40e60"
     let chainName = "main"
     let network = DarksideWalletDNetwork()
@@ -47,18 +46,6 @@ class PendingTransactionUpdatesTest: XCTestCase {
         try? FileManager.default.removeItem(at: coordinator.databases.fsCacheDbRoot)
         try? FileManager.default.removeItem(at: coordinator.databases.dataDB)
         try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
-    }
-    
-    @objc func handleReorg(_ notification: Notification) {
-        guard
-            let reorgHeight = notification.userInfo?[CompactBlockProcessorNotificationKey.reorgHeight] as? BlockHeight
-        else {
-            XCTFail("empty reorg notification")
-            return
-        }
-        
-        XCTAssertEqual(reorgHeight, expectedReorgHeight)
-        reorgExpectation.fulfill()
     }
     
     func testPendingTransactionMinedHeightUpdated() async throws {
@@ -239,14 +226,5 @@ class PendingTransactionUpdatesTest: XCTestCase {
             return
         }
         XCTFail("Failed with error: \(testError)")
-    }
-    
-    func hookToReOrgNotification() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleReorg(_:)),
-            name: .blockProcessorHandledReOrg,
-            object: nil
-        )
     }
 }

--- a/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
+++ b/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
@@ -1,0 +1,63 @@
+//
+//  CompactBlockProcessorEventHandler.swift
+//  
+//
+//  Created by Michal Fousek on 09.02.2023.
+//
+
+import Combine
+import Foundation
+import XCTest
+@testable import ZcashLightClientKit
+
+class CompactBlockProcessorEventHandler {
+    enum EventIdentifier: String {
+        case failed
+        case finished
+        case foundTransactions
+        case handleReorg
+        case progressUpdated
+        case storedUTXOs
+        case startedEnhancing
+        case startedFetching
+        case startedSyncing
+        case stopped
+    }
+
+    private let queue = DispatchQueue(label: "CompactBlockProcessorEventHandler")
+    private var cancelables: [AnyCancellable] = []
+
+    func subscribe(to eventStream: AnyPublisher<CompactBlockProcessor.Event, Never>, expectations: [EventIdentifier: XCTestExpectation]) {
+        eventStream
+            .receive(on: queue)
+            .sink { event in expectations[event.identifier]?.fulfill() }
+            .store(in: &cancelables)
+    }
+}
+
+extension CompactBlockProcessor.Event {
+    var identifier: CompactBlockProcessorEventHandler.EventIdentifier {
+        switch self {
+        case .failed:
+            return .failed
+        case .finished:
+            return .finished
+        case .foundTransactions:
+            return .foundTransactions
+        case .handledReorg:
+            return .handleReorg
+        case .progressUpdated:
+            return .progressUpdated
+        case .storedUTXOs:
+            return .storedUTXOs
+        case .startedEnhancing:
+            return .startedEnhancing
+        case .startedFetching:
+            return .startedFetching
+        case .startedSyncing:
+            return .startedSyncing
+        case .stopped:
+            return .stopped
+        }
+    }
+}


### PR DESCRIPTION
Closes #764

- All notification that were previously sent from CompactBlockProcessor are now gone.
- `CompactBlockProcessor` now provides `eventStream` to communicate with `SDKSynchronizer`.
- Added `synchronizerStoredUTXOs` notification.
- Tests are updated to not use notifications anymore. Some tests there weren't working before are now fixed.
- Added `CompactBlockProcessorEventHandler` utility class. Previously expectations were subscribing to notifications. This class replaces this functionality. It subscribes to events from `CompactBlockProcessor` and fullfill expectations.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.