### PR TITLE
[#801] Improve wipe implementation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,7 @@ disabled_rules:
   - multiple_closures_with_trailing_closure 
   - generic_type_name # allow for arbitrarily long generic type names
   - redundant_void_return
+  - empty_parentheses_with_trailing_closure
 
 opt_in_rules:
   - mark
@@ -148,6 +149,7 @@ identifier_name:
 
 indentation_width:
   indentation_width: 4
+  include_comments: false
 
 line_length:
   warning: 150

--- a/.swiftlint_tests.yml
+++ b/.swiftlint_tests.yml
@@ -21,6 +21,7 @@ disabled_rules:
   - multiple_closures_with_trailing_closure 
   - generic_type_name # allow for arbitrarily long generic type names
   - redundant_void_return
+  - empty_parentheses_with_trailing_closure
   - implicitly_unwrapped_optional
   - force_unwrapping
   - type_body_length
@@ -138,6 +139,7 @@ identifier_name:
 
 indentation_width:
   indentation_width: 4
+  include_comments: false
 
 line_length:
   warning: 150

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
+- [#801] Improve how wipe call can be used
+
+    `SDKSynchronizer.wipe()` function can be now called anytime. It returns `AnyPublisher` which
+completes or fails when the wipe is done. For more details read the documentation for this method 
+in the code.
+
 - [#793] Send synchronizerStopped notification only when sync process stops
     
     `synchronizerStopped` notification is now sent after the sync process stops. It's

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
@@ -45,6 +45,12 @@ class SyncBlocksViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .trash,
+            target: self,
+            action: #selector(wipe(_:))
+        )
+
         statusLabel.text = textFor(state: synchronizer.status)
         progressBar.progress = 0
         let center = NotificationCenter.default
@@ -339,5 +345,69 @@ extension SDKMetrics.BlockMetricReport: CustomDebugStringConvertible {
             batchSize: \(self.batchSize)
             duration: \(self.duration)
         """
+    }
+}
+
+// MARK: Wipe
+
+extension SyncBlocksViewController {
+    @objc func wipe(_ sender: Any?) {
+        let alert = UIAlertController(
+            title: "Wipe the wallet?",
+            message: """
+            You are about to clear existing databases. All synced blocks, stored TXs, etc will be removed form this device only. If the sync is in
+            progress it may take some time. Please be patient.
+            """,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(
+            UIAlertAction(
+                title: "Drop it like it's FIAT",
+                style: UIAlertAction.Style.destructive
+            ) { [weak self] _ in
+                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                appDelegate.wipe() { [weak self] possibleError in
+                    if let error = possibleError {
+                        self?.wipeFailedAlert(error: error)
+                    } else {
+                        self?.wipeSuccessfullAlert()
+                    }
+                }
+            }
+        )
+
+        alert.addAction(UIAlertAction(title: "No please! Have mercy!", style: UIAlertAction.Style.cancel, handler: nil))
+
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func wipeSuccessfullAlert() {
+        let alert = UIAlertController(
+            title: "Wipe is done!",
+            message: nil,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func wipeFailedAlert(error: Error) {
+        loggerProxy.error("Wipe error: \(error)")
+
+        let alert = UIAlertController(
+            title: "Wipe FAILED!",
+            message: """
+            Something bad happened and wipe failed. This may happen only when some basic IO disk operations failed. The SDK may end up in \
+            inconsistent state. It's suggested to call the wipe again until it succeeds. Sorry.
+
+            \(error)
+            """,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
     }
 }

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Transaction Detail/TransactionDetailViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Transaction Detail/TransactionDetailViewController.swift
@@ -57,7 +57,7 @@ final class TransactionDetailModel {
         self.minedHeight = transaction.minedHeight?.description
         self.expiryHeight = transaction.expiryHeight?.description
         self.created = transaction.blockTime?.description
-        self.zatoshi = "not available in this entity"
+        self.zatoshi = NumberFormatter.zcashNumberFormatter.string(from: NSNumber(value: transaction.value.amount))
         self.memo = memos.first?.toString()
     }
 }

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/ViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/ViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Electric Coin Company. All rights reserved.
 //
 
+import Combine
 import UIKit
 
 class MainTableViewController: UITableViewController {
@@ -15,14 +16,17 @@ class MainTableViewController: UITableViewController {
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .trash,
             target: self,
-            action: #selector(clearDatabases(_:))
+            action: #selector(wipe(_:))
         )
     }
     
-    @objc func clearDatabases(_ sender: Any?) {
+    @objc func wipe(_ sender: Any?) {
         let alert = UIAlertController(
-            title: "Clear Databases?",
-            message: "You are about to clear existing databases. You will lose all synced blocks, stored TXs, etc",
+            title: "Wipe the wallet?",
+            message: """
+            You are about to clear existing databases. All synced blocks, stored TXs, etc will be removed form this device only. If the sync is in
+            progress it may take some time. Please be patient.
+            """,
             preferredStyle: .alert
         )
 
@@ -30,17 +34,49 @@ class MainTableViewController: UITableViewController {
             UIAlertAction(
                 title: "Drop it like it's FIAT",
                 style: UIAlertAction.Style.destructive
-            ) { _ in
-                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-                    return
+            ) { [weak self] _ in
+                guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+                appDelegate.wipe() { [weak self] possibleError in
+                    if let error = possibleError {
+                        self?.wipeFailedAlert(error: error)
+                    } else {
+                        self?.wipeSuccessfullAlert()
+                    }
                 }
-
-                appDelegate.clearDatabases()
             }
         )
 
         alert.addAction(UIAlertAction(title: "No please! Have mercy!", style: UIAlertAction.Style.cancel, handler: nil))
         
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func wipeSuccessfullAlert() {
+        let alert = UIAlertController(
+            title: "Wipe is done!",
+            message: nil,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
+    }
+
+    private func wipeFailedAlert(error: Error) {
+        loggerProxy.error("Wipe error: \(error)")
+
+        let alert = UIAlertController(
+            title: "Wipe FAILED!",
+            message: """
+            Something bad happened and wipe failed. This may happen only when some basic IO disk operations failed. The SDK may end up in \
+            inconsistent state. It's suggested to call the wipe again until it succeeds. Sorry.
+
+            \(error)
+            """,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: nil))
         self.present(alert, animated: true, completion: nil)
     }
     

--- a/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
@@ -1,0 +1,69 @@
+//
+//  AfterSyncHooksManager.swift
+//  
+//
+//  Created by Michal Fousek on 20.02.2023.
+//
+
+import Foundation
+
+class AfterSyncHooksManager {
+    struct WipeContext {
+        let pendingDbURL: URL
+        let prewipe: () -> Void
+        let completion: (Error?) -> Void
+    }
+
+    enum Hook: Equatable, Hashable {
+        case wipe(WipeContext)
+        case anotherSync
+
+        static func == (lhs: Hook, rhs: Hook) -> Bool {
+            switch (lhs, rhs) {
+            case (.wipe, .wipe):
+                return true
+            case (.anotherSync, .anotherSync):
+                return true
+            default:
+                return false
+            }
+        }
+
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .wipe: hasher.combine(0)
+            case .anotherSync: hasher.combine(1)
+            }
+        }
+
+        static var emptyWipe: Hook {
+            return .wipe(
+                WipeContext(
+                    pendingDbURL: URL(fileURLWithPath: "/"),
+                    prewipe: { },
+                    completion: { _ in }
+                )
+            )
+        }
+    }
+
+    private var hooks: Set<Hook> = []
+
+    init() { }
+
+    func insert(hook: Hook) {
+        hooks.insert(hook)
+    }
+
+    func shouldExecuteWipeHook() -> WipeContext? {
+        if case let .wipe(wipeContext) = hooks.first(where: { $0 == Hook.emptyWipe }) {
+            return wipeContext
+        } else {
+            return nil
+        }
+    }
+
+    func shouldExecuteAnotherSyncHook() -> Bool {
+        return hooks.first(where: { $0 == .anotherSync }) != nil
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Electric Coin Company. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 /// Represents errors thrown by a Synchronizer
@@ -212,8 +213,17 @@ public protocol Synchronizer {
     /// Wipes out internal data structures of the SDK. After this call, everything is the same as before any sync. The state of the synchronizer is
     /// switched to `unprepared`. So before the next sync, it's required to call `prepare()`.
     ///
-    /// If this is called while the sync process is in progress then `SynchronizerError.wipeAttemptWhileProcessing` is thrown.
-    func wipe() async throws
+    /// `wipe()` can be called anytime. If the sync process is in progress then it is stopped first. In this case, it make some significant time
+    /// before wipe finishes. If `wipe()` is called don't call it again until publisher returned from first call finishes. Calling it again earlier
+    /// results in undefined behavior.
+    ///
+    /// Returned publisher either completes or fails when the wipe is done. It doesn't emits any value.
+    ///
+    /// Majority of wipe's work is to delete files. That is only operation that can throw error during wipe. This should succeed every time. If this
+    /// fails then something is seriously wrong. If the wipe fails then the SDK may be in inconsistent state. It's suggested to call wipe again until
+    /// it succeed.
+    ///
+    func wipe() -> AnyPublisher<Void, Error>
 }
 
 public enum SyncStatus: Equatable {

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -15,8 +15,6 @@ final class SynchronizerTests: XCTestCase {
     var birthday: BlockHeight = 663150
     let defaultLatestHeight: BlockHeight = 663175
     var coordinator: TestCoordinator!
-    var syncedExpectation = XCTestExpectation(description: "synced")
-    var sentTransactionExpectation = XCTestExpectation(description: "sent")
     var expectedReorgHeight: BlockHeight = 665188
     var expectedRewindHeight: BlockHeight = 665188
     var reorgExpectation = XCTestExpectation(description: "reorg")
@@ -24,7 +22,6 @@ final class SynchronizerTests: XCTestCase {
     let chainName = "main"
     let network = DarksideWalletDNetwork()
     var cancellables: [AnyCancellable] = []
-    var processorEventHandler: CompactBlockProcessorEventHandler! = CompactBlockProcessorEventHandler()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -57,7 +54,6 @@ final class SynchronizerTests: XCTestCase {
         try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
         coordinator = nil
         cancellables = []
-        processorEventHandler = nil
     }
 
     func handleReorg(event: CompactBlockProcessor.Event) {
@@ -102,11 +98,150 @@ final class SynchronizerTests: XCTestCase {
         try await Task.sleep(nanoseconds: 5_000_000_000)
         self.coordinator.synchronizer.stop()
 
-        wait(for: [syncStoppedExpectation], timeout: 6, enforceOrder: true)
+        wait(for: [syncStoppedExpectation], timeout: 6)
 
         XCTAssertEqual(coordinator.synchronizer.status, .stopped)
         let state = await coordinator.synchronizer.blockProcessor.state
         XCTAssertEqual(state, .stopped)
+    }
+
+    @MainActor func testWipeCalledWhichSyncDoesntRun() async throws {
+        /*
+         create fake chain
+         */
+        let fullSyncLength = 1000
+
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName, length: fullSyncLength)
+
+        try coordinator.applyStaged(blockheight: birthday + fullSyncLength)
+
+        sleep(2)
+
+        let syncFinished = XCTestExpectation(description: "SynchronizerSyncFinished Expectation")
+
+        /*
+         sync to latest height
+         */
+        try coordinator.sync(
+            completion: { _ in
+                syncFinished.fulfill()
+            },
+            error: handleError
+        )
+
+        wait(for: [syncFinished], timeout: 3)
+
+        let wipeFinished = XCTestExpectation(description: "SynchronizerWipeFinished Expectation")
+
+        /*
+         Call wipe
+         */
+        coordinator.synchronizer.wipe()
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        wipeFinished.fulfill()
+
+                    case .failure(let error):
+                        XCTFail("Wipe should finish successfully. \(error)")
+                    }
+                },
+                receiveValue: {
+                    XCTFail("No no value should be received from wipe.")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [wipeFinished], timeout: 1)
+
+        /*
+         Check that wipe cleared everything that is expected
+         */
+        await checkThatWipeWorked()
+    }
+
+    @MainActor func testWipeCalledWhileSyncRuns() async throws {
+        /*
+         1. create fake chain
+         */
+        let fullSyncLength = 50_000
+
+        try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName, length: fullSyncLength)
+
+        try coordinator.applyStaged(blockheight: birthday + fullSyncLength)
+
+        sleep(5)
+
+        /*
+         Start sync
+         */
+        try coordinator.sync(completion: { _ in
+            XCTFail("Sync should have stopped")
+        }, error: { error in
+            _ = try? self.coordinator.stop()
+
+            guard let testError = error else {
+                XCTFail("failed with nil error")
+                return
+            }
+            XCTFail("Failed with error: \(testError)")
+        })
+
+        try await Task.sleep(nanoseconds: 2_000_000_000)
+
+        // Just to be sure that blockProcessor is still syncing and that this test does what it should.
+        let blockProcessorState = await coordinator.synchronizer.blockProcessor.state
+        XCTAssertEqual(blockProcessorState, .syncing)
+
+        let wipeFinished = XCTestExpectation(description: "SynchronizerWipeFinished Expectation")
+        /*
+         Call wipe
+         */
+        coordinator.synchronizer.wipe()
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        wipeFinished.fulfill()
+
+                    case .failure(let error):
+                        XCTFail("Wipe should finish successfully. \(error)")
+                    }
+                },
+                receiveValue: {
+                    XCTFail("No no value should be received from wipe.")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [wipeFinished], timeout: 6)
+
+        /*
+         Check that wipe cleared everything that is expected
+         */
+        await checkThatWipeWorked()
+    }
+
+    private func checkThatWipeWorked() async {
+        let storage = await self.coordinator.synchronizer.blockProcessor.storage as! FSCompactBlockRepository
+        let fm = FileManager.default
+        XCTAssertFalse(fm.fileExists(atPath: coordinator.synchronizer.initializer.dataDbURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: coordinator.synchronizer.initializer.pendingDbURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: storage.blocksDirectory.path))
+
+        let internalSyncProgress = InternalSyncProgress(storage: UserDefaults.standard)
+
+        let latestDownloadedBlockHeight = await internalSyncProgress.load(.latestDownloadedBlockHeight)
+        let latestEnhancedHeight = await internalSyncProgress.load(.latestEnhancedHeight)
+        let latestUTXOFetchedHeight = await internalSyncProgress.load(.latestUTXOFetchedHeight)
+
+        XCTAssertEqual(latestDownloadedBlockHeight, 0)
+        XCTAssertEqual(latestEnhancedHeight, 0)
+        XCTAssertEqual(latestUTXOFetchedHeight, 0)
+
+        let blockProcessorState = await coordinator.synchronizer.blockProcessor.state
+        XCTAssertEqual(blockProcessorState, .stopped)
     }
 
     func handleError(_ error: Error?) {


### PR DESCRIPTION
Closes #801

- `SDKSynchronizer.wipe()` can be now called anytime.
- If the sync is in progress then the sync is first stopped and then wipe is executed.
- Wipe now returns AnyPublisher which completes or fails when wipe is done.
- Majority of wipe's work is to delete files. That is only operation
      that can throw error during wipe. This operation should succeed every
      time. If it fails that something is seriously wrong. When this happens
      the SDK can happen in inconsistent state. There is no recovery for
      now. Only way how to fix this is to reinstall the app in the device.
- Added hooks mechanism. This is implemented in `AfterSyncHooksManager`
      and it is used by `CompactBlockProcessor`. It's just more organized
      way how to track what should happen when the sync process is canceled.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.