### PR TITLE
[#826] Change how the SDK is initialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# unreleased 
+- [#826] Change how the SDK is initialized
+    
+    - `viewingKeys` and `walletBirthday` are removed from `Initializer` constuctor. These parameters
+are moved to `SDKSynchronizer.prepare` function.
+    - Constructor of the `SDKSynchronizer` no longer throws exception.
+    - Any value emitted from `lastState` stream before `SDKSynchronizer.prepare` is called has 
+`latestScannedHeight` set to 0.
+    - `Initializer.initialize` function isn't public anymore. To initialize SDK call `SDKSynchronizer.prepare` 
+instead. 
+
+
 # 0.19.1-beta
 ## Checkpoints added
 Mainnet

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
@@ -25,20 +25,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let sync = synchronizer {
             return sync
         } else {
-            let sync = try! SDKSynchronizer(initializer: sharedWallet) // this must break if fails
+            let sync = SDKSynchronizer(initializer: sharedWallet) // this must break if fails
             self.synchronizer = sync
             return sync
         }
+    }
+
+    var sharedViewingKey: UnifiedFullViewingKey {
+        return try! DerivationTool(networkType: kZcashNetwork.networkType)
+            .deriveUnifiedSpendingKey(seed: DemoAppConfig.seed, accountIndex: 0)
+            .deriveFullViewingKey()
     }
     
     var sharedWallet: Initializer {
         if let wallet = wallet {
             return wallet
         } else {
-            let ufvk = try! DerivationTool(networkType: kZcashNetwork.networkType)
-                .deriveUnifiedSpendingKey(seed: DemoAppConfig.seed, accountIndex: 0)
-                .deriveFullViewingKey()
-
             let wallet = Initializer(
                 fsBlockDbRoot: try! fsBlockDbRootURLHelper(),
                 dataDbURL: try! dataDbURLHelper(),
@@ -48,12 +50,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 spendParamsURL: try! spendParamsURLHelper(),
                 outputParamsURL: try! outputParamsURLHelper(),
                 saplingParamsSourceURL: SaplingParamsSourceURL.default,
-                viewingKeys: [ufvk],
-                walletBirthday: DemoAppConfig.birthdayHeight,
                 loggerProxy: loggerProxy
             )
-            
-            _ = try! wallet.initialize(with: DemoAppConfig.seed)
            
             self.wallet = wallet
             return wallet

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Send/SendViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Send/SendViewController.swift
@@ -38,7 +38,11 @@ class SendViewController: UIViewController {
         setUp()
         Task { @MainActor in
             // swiftlint:disable:next force_try
-            try! await synchronizer.prepare(with: DemoAppConfig.seed)
+            try! synchronizer.prepare(
+                with: DemoAppConfig.seed,
+                viewingKeys: [AppDelegate.shared.sharedViewingKey],
+                walletBirthday: DemoAppConfig.birthdayHeight
+            )
         }
     }
     

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
@@ -173,7 +173,11 @@ class SyncBlocksViewController: UIViewController {
         case .stopped, .unprepared:
             do {
                 if synchronizer.status == .unprepared {
-                    _ = try synchronizer.prepare(with: DemoAppConfig.seed)
+                    _ = try synchronizer.prepare(
+                        with: DemoAppConfig.seed,
+                        viewingKeys: [AppDelegate.shared.sharedViewingKey],
+                        walletBirthday: DemoAppConfig.birthdayHeight
+                    )
                 }
 
                 SDKMetrics.shared.enableMetrics()

--- a/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
+++ b/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
@@ -15,7 +15,7 @@ enum UTXOFetcherError: Error {
 struct UTXOFetcherConfig {
     let dataDb: URL
     let networkType: NetworkType
-    let walletBirthday: Int
+    let walletBirthdayProvider: () -> BlockHeight
 }
 
 protocol UTXOFetcher {
@@ -48,7 +48,7 @@ extension UTXOFetcherImpl: UTXOFetcher {
         var utxos: [UnspentTransactionOutputEntity] = []
         let stream: AsyncThrowingStream<UnspentTransactionOutputEntity, Error> = blockDownloaderService.fetchUnspentTransactionOutputs(
             tAddresses: tAddresses.map { $0.stringEncoded },
-            startHeight: config.walletBirthday
+            startHeight: config.walletBirthdayProvider()
         )
 
         for try await transaction in stream {

--- a/Sources/ZcashLightClientKit/Block/Utils/InternalSyncProgress.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/InternalSyncProgress.swift
@@ -148,15 +148,15 @@ actor InternalSyncProgress {
 
         if latestScannedHeight > latestDownloadedBlockHeight {
             LoggerProxy.warn("""
-                             InternalSyncProgress found inconsistent state.
-                                 latestBlockHeight:       \(latestBlockHeight)
-                             --> latestDownloadedHeight:  \(latestDownloadedBlockHeight)
-                                 latestScannedHeight:     \(latestScannedHeight)
-                                 latestEnhancedHeight:    \(latestEnhancedHeight)
-                                 latestUTXOFetchedHeight: \(latestUTXOFetchedHeight)
+            InternalSyncProgress found inconsistent state.
+                latestBlockHeight:       \(latestBlockHeight)
+            --> latestDownloadedHeight:  \(latestDownloadedBlockHeight)
+                latestScannedHeight:     \(latestScannedHeight)
+                latestEnhancedHeight:    \(latestEnhancedHeight)
+                latestUTXOFetchedHeight: \(latestUTXOFetchedHeight)
 
-                             latest downloaded height
-                             """)
+            latest downloaded height
+            """)
         }
 
         // compute the range that must be downloaded and scanned based on

--- a/Sources/ZcashLightClientKit/DAO/UnspentTransactionOutputDao.swift
+++ b/Sources/ZcashLightClientKit/DAO/UnspentTransactionOutputDao.swift
@@ -86,6 +86,10 @@ class UnspentTransactionOutputSQLDAO: UnspentTransactionOutputRepository {
     init (dbProvider: ConnectionProvider) {
         self.dbProvider = dbProvider
     }
+
+    func initialise() throws {
+        try createTableIfNeeded()
+    }
     
     func createTableIfNeeded() throws {
         let stringStatement =
@@ -182,9 +186,7 @@ struct TransparentBalance {
 }
 
 enum UTXORepositoryBuilder {
-    static func build(initializer: Initializer) throws -> UnspentTransactionOutputRepository {
-        let dao = UnspentTransactionOutputSQLDAO(dbProvider: SimpleConnectionProvider(path: initializer.dataDbURL.path))
-        try dao.createTableIfNeeded()
-        return dao
+    static func build(initializer: Initializer) -> UnspentTransactionOutputRepository {
+        return UnspentTransactionOutputSQLDAO(dbProvider: SimpleConnectionProvider(path: initializer.dataDbURL.path))
     }
 }

--- a/Sources/ZcashLightClientKit/Repository/UnspentTransactionOutputRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/UnspentTransactionOutputRepository.swift
@@ -8,11 +8,9 @@
 import Foundation
 
 protocol UnspentTransactionOutputRepository {
+    func initialise() throws
     func getAll(address: String?) throws -> [UnspentTransactionOutputEntity]
-    
     func balance(address: String, latestHeight: BlockHeight) throws -> WalletBalance
-    
     func store(utxos: [UnspentTransactionOutputEntity]) throws
-    
     func clearAll(address: String?) throws
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -75,9 +75,27 @@ public protocol Synchronizer {
     /// reflects current connection state to LightwalletEndpoint
     var connectionState: ConnectionState { get }
 
-    /// prepares this initializer to operate. Initializes the internal state with the given
-    /// Extended Viewing Keys and a wallet birthday found in the initializer object
-    func prepare(with seed: [UInt8]?) async throws -> Initializer.InitializationResult
+    /// Initialize the wallet. The ZIP-32 seed bytes can optionally be passed to perform
+    /// database migrations. most of the times the seed won't be needed. If they do and are
+    /// not provided this will fail with `InitializationResult.seedRequired`. It could
+    /// be the case that this method is invoked by a wallet that does not contain the seed phrase
+    /// and is view-only, or by a wallet that does have the seed but the process does not have the
+    /// consent of the OS to fetch the keys from the secure storage, like on background tasks.
+    ///
+    /// 'cache.db' and 'data.db' files are created by this function (if they
+    /// do not already exist). These files can be given a prefix for scenarios where multiple wallets
+    ///
+    /// - Parameters:
+    ///   - seed: ZIP-32 Seed bytes for the wallet that will be initialized.
+    ///   - viewingKeys: Viewing key derived from seed.
+    ///   - walletBirthday: Birthday of wallet.
+    /// - Throws: `InitializerError.dataDbInitFailed` if the creation of the dataDb fails
+    /// `InitializerError.accountInitFailed` if the account table can't be initialized.
+    func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight
+    ) throws -> Initializer.InitializationResult
 
     /// Starts this synchronizer within the given scope.
     ///

--- a/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
@@ -268,18 +268,18 @@ class PersistentTransactionManager: OutboundTransactionManager {
 }
 
 enum OutboundTransactionManagerBuilder {
-    static func build(initializer: Initializer) throws -> OutboundTransactionManager {
+    static func build(initializer: Initializer) -> OutboundTransactionManager {
         PersistentTransactionManager(
             encoder: TransactionEncoderbuilder.build(initializer: initializer),
             service: initializer.lightWalletService,
-            repository: try PendingTransactionRepositoryBuilder.build(initializer: initializer),
+            repository: PendingTransactionRepositoryBuilder.build(initializer: initializer),
             networkType: initializer.network.networkType
         )
     }
 }
 
 enum PendingTransactionRepositoryBuilder {
-    static func build(initializer: Initializer) throws -> PendingTransactionRepository {
+    static func build(initializer: Initializer) -> PendingTransactionRepository {
         PendingTransactionSQLDAO(dbProvider: SimpleConnectionProvider(path: initializer.pendingDbURL.path, readonly: false))
     }
 }

--- a/Tests/DarksideTests/AdvancedReOrgTests.swift
+++ b/Tests/DarksideTests/AdvancedReOrgTests.swift
@@ -28,7 +28,6 @@ class AdvancedReOrgTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: birthday + 50, // don't use an exact birthday, users never do.
             network: network
         )
@@ -326,7 +325,7 @@ class AdvancedReOrgTests: XCTestCase {
         */
         do {
             let pendingTx = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: coordinator.spendingKeys!.first!,
+                spendingKey: coordinator.spendingKey,
                 zatoshi: sendAmount,
                 toAddress: try Recipient(Environment.testRecipientAddress, network: self.network.networkType),
                 memo: try Memo(string: "test transaction")
@@ -753,7 +752,7 @@ class AdvancedReOrgTests: XCTestCase {
         */
         do {
             let pendingTx = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: self.coordinator.spendingKeys!.first!,
+                spendingKey: self.coordinator.spendingKey,
                 zatoshi: Zatoshi(20000),
                 toAddress: try Recipient(Environment.testRecipientAddress, network: self.network.networkType),
                 memo: try Memo(string: "this is a test")
@@ -1142,7 +1141,7 @@ class AdvancedReOrgTests: XCTestCase {
         */
         do {
             let pendingTx = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: self.coordinator.spendingKeys!.first!,
+                spendingKey: self.coordinator.spendingKey,
                 zatoshi: Zatoshi(20000),
                 toAddress: try Recipient(Environment.testRecipientAddress, network: self.network.networkType),
                 memo: try! Memo(string: "this is a test")

--- a/Tests/DarksideTests/BalanceTests.swift
+++ b/Tests/DarksideTests/BalanceTests.swift
@@ -24,7 +24,6 @@ class BalanceTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -84,10 +83,7 @@ class BalanceTests: XCTestCase {
         
         // 3 create a transaction for the max amount possible
         // 4 send the transaction
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
 
         var pendingTx: PendingTransactionEntity?
         do {
@@ -243,11 +239,7 @@ class BalanceTests: XCTestCase {
         
         // 3 create a transaction for the max amount possible
         // 4 send the transaction
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
-        
+        let spendingKey = coordinator.spendingKey
         var pendingTx: PendingTransactionEntity?
         do {
             let transaction = try await coordinator.synchronizer.sendToAddress(
@@ -402,10 +394,7 @@ class BalanceTests: XCTestCase {
         
         // 3 create a transaction for the max amount possible
         // 4 send the transaction
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
         var pendingTx: PendingTransactionEntity?
         do {
             let transaction = try await coordinator.synchronizer.sendToAddress(
@@ -556,10 +545,7 @@ class BalanceTests: XCTestCase {
         
         wait(for: [syncedExpectation], timeout: 60)
         
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
         
         let presendVerifiedBalance: Zatoshi = coordinator.synchronizer.initializer.getVerifiedBalance()
         
@@ -738,11 +724,8 @@ class BalanceTests: XCTestCase {
         
         wait(for: [syncedExpectation], timeout: 5)
         
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
-        
+        let spendingKey = coordinator.spendingKey
+
         let presendBalance: Zatoshi = coordinator.synchronizer.initializer.getBalance()
 
         // there's more zatoshi to send than network fee
@@ -909,10 +892,7 @@ class BalanceTests: XCTestCase {
         let previousVerifiedBalance: Zatoshi = coordinator.synchronizer.initializer.getVerifiedBalance()
         let previousTotalBalance: Zatoshi = coordinator.synchronizer.initializer.getBalance()
         
-        guard let spendingKeys = coordinator.spendingKeys?.first else {
-            XCTFail("null spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
         
         /*
         Send
@@ -921,7 +901,7 @@ class BalanceTests: XCTestCase {
         var pendingTx: PendingTransactionEntity?
         do {
             let transaction = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: spendingKeys,
+                spendingKey: spendingKey,
                 zatoshi: sendAmount,
                 toAddress: try Recipient(Environment.testRecipientAddress, network: self.network.networkType),
                 memo: memo
@@ -1088,10 +1068,7 @@ class BalanceTests: XCTestCase {
         }
         wait(for: [syncedExpectation], timeout: 5)
         
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("no synchronizer or spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
         
         let previousVerifiedBalance: Zatoshi = coordinator.synchronizer.initializer.getVerifiedBalance()
         let previousTotalBalance: Zatoshi = coordinator.synchronizer.initializer.getBalance()

--- a/Tests/DarksideTests/DarksideSanityCheckTests.swift
+++ b/Tests/DarksideTests/DarksideSanityCheckTests.swift
@@ -27,7 +27,6 @@ class DarksideSanityCheckTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )

--- a/Tests/DarksideTests/InternalStateConsistencyTests.swift
+++ b/Tests/DarksideTests/InternalStateConsistencyTests.swift
@@ -24,7 +24,6 @@ final class InternalStateConsistencyTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: birthday + 50, // don't use an exact birthday, users never do.
             network: network
         )

--- a/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
+++ b/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
@@ -25,7 +25,6 @@ class PendingTransactionUpdatesTest: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -83,7 +82,7 @@ class PendingTransactionUpdatesTest: XCTestCase {
         LoggerProxy.info("2. send transaction to recipient address")
         do {
             let pendingTx = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: self.coordinator.spendingKeys!.first!,
+                spendingKey: self.coordinator.spendingKey,
                 zatoshi: Zatoshi(20000),
                 toAddress: try Recipient(Environment.testRecipientAddress, network: self.network.networkType),
                 memo: try Memo(string: "this is a test")

--- a/Tests/DarksideTests/ReOrgTests.swift
+++ b/Tests/DarksideTests/ReOrgTests.swift
@@ -45,7 +45,6 @@ class ReOrgTests: XCTestCase {
         try super.setUpWithError()
 
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )

--- a/Tests/DarksideTests/RewindRescanTests.swift
+++ b/Tests/DarksideTests/RewindRescanTests.swift
@@ -30,7 +30,6 @@ class RewindRescanTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -363,10 +362,7 @@ class RewindRescanTests: XCTestCase {
         
         // 3 create a transaction for the max amount possible
         // 4 send the transaction
-        guard let spendingKey = coordinator.spendingKeys?.first else {
-            XCTFail("failed to create spending keys")
-            return
-        }
+        let spendingKey = coordinator.spendingKey
         var pendingTx: PendingTransactionEntity?
         do {
             let transaction = try await coordinator.synchronizer.sendToAddress(

--- a/Tests/DarksideTests/ShieldFundsTests.swift
+++ b/Tests/DarksideTests/ShieldFundsTests.swift
@@ -25,7 +25,6 @@ class ShieldFundsTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: birthday,
             network: network
         )

--- a/Tests/DarksideTests/SychronizerDarksideTests.swift
+++ b/Tests/DarksideTests/SychronizerDarksideTests.swift
@@ -30,7 +30,6 @@ class SychronizerDarksideTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -159,7 +158,7 @@ class SychronizerDarksideTests: XCTestCase {
                 shieldedBalance: .zero,
                 transparentBalance: .zero,
                 syncStatus: .unprepared,
-                latestScannedHeight: self.birthday
+                latestScannedHeight: .zero
             ),
             SDKSynchronizer.SynchronizerState(
                 shieldedBalance: WalletBalance(verified: Zatoshi(0), total: Zatoshi(0)),
@@ -216,7 +215,7 @@ class SychronizerDarksideTests: XCTestCase {
 
         wait(for: [wipeFinished], timeout: 1)
 
-        _ = try coordinator.synchronizer.prepare(with: nil)
+        _ = try coordinator.prepare(seed: Environment.seedBytes)
 
         let secondSyncExpectation = XCTestExpectation(description: "second sync")
 

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -26,7 +26,6 @@ final class SynchronizerTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday + 50, // don't use an exact birthday, users never do.
             network: self.network
         )
@@ -230,7 +229,8 @@ final class SynchronizerTests: XCTestCase {
         let fm = FileManager.default
         XCTAssertFalse(fm.fileExists(atPath: coordinator.synchronizer.initializer.dataDbURL.path))
         XCTAssertFalse(fm.fileExists(atPath: coordinator.synchronizer.initializer.pendingDbURL.path))
-        XCTAssertFalse(fm.fileExists(atPath: storage.blocksDirectory.path))
+        XCTAssertTrue(fm.fileExists(atPath: storage.blocksDirectory.path))
+        XCTAssertEqual(try fm.contentsOfDirectory(atPath: storage.blocksDirectory.path), [])
 
         let internalSyncProgress = InternalSyncProgress(storage: UserDefaults.standard)
 
@@ -244,6 +244,8 @@ final class SynchronizerTests: XCTestCase {
 
         let blockProcessorState = await coordinator.synchronizer.blockProcessor.state
         XCTAssertEqual(blockProcessorState, .stopped)
+
+        XCTAssertEqual(coordinator.synchronizer.status, .unprepared)
     }
 
     func handleError(_ error: Error?) {

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -67,7 +67,7 @@ class TransactionEnhancementTests: XCTestCase {
             spendParamsURL: pathProvider.spendParamsURL,
             outputParamsURL: pathProvider.outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: birthday.height,
+            walletBirthdayProvider: { birthday.height },
             network: network
         )
 
@@ -78,7 +78,7 @@ class TransactionEnhancementTests: XCTestCase {
         
         let ufvks = [
             try DerivationTool(networkType: network.networkType)
-                .deriveUnifiedSpendingKey(seed: TestSeed().seed(), accountIndex: 0)
+                .deriveUnifiedSpendingKey(seed: Environment.seedBytes, accountIndex: 0)
                 .map {
                     try DerivationTool(networkType: network.networkType)
                         .deriveUnifiedFullViewingKey(from: $0)

--- a/Tests/DarksideTests/Z2TReceiveTests.swift
+++ b/Tests/DarksideTests/Z2TReceiveTests.swift
@@ -26,7 +26,6 @@ class Z2TReceiveTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         self.coordinator = try TestCoordinator(
-            seed: Environment.seedPhrase,
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -96,7 +95,7 @@ class Z2TReceiveTests: XCTestCase {
         */
         do {
             _ = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: coordinator.spendingKeys!.first!,
+                spendingKey: coordinator.spendingKey,
                 zatoshi: sendAmount,
                 toAddress: try! Recipient(testRecipientAddress, network: self.network.networkType),
                 memo: try Memo(string: "test transaction")
@@ -152,7 +151,7 @@ class Z2TReceiveTests: XCTestCase {
         */
         do {
             let pending = try await coordinator.synchronizer.sendToAddress(
-                spendingKey: coordinator.spendingKeys!.first!,
+                spendingKey: coordinator.spendingKey,
                 zatoshi: sendAmount,
                 toAddress: try! Recipient(testRecipientAddress, network: self.network.networkType),
                 memo: nil

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -96,7 +96,7 @@ class BlockScanTests: XCTestCase {
             spendParamsURL: spendParamsURL,
             outputParamsURL: outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: walletBirthDay.height,
+            walletBirthdayProvider: { [weak self] in self?.walletBirthDay.height ?? .zero },
             network: network
         )
 
@@ -185,7 +185,7 @@ class BlockScanTests: XCTestCase {
             spendParamsURL: spendParamsURL,
             outputParamsURL: outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: network.constants.saplingActivationHeight,
+            walletBirthdayProvider: { [weak self] in self?.network.constants.saplingActivationHeight ?? .zero },
             network: network
         )
         processorConfig.scanningBatchSize = 1000

--- a/Tests/NetworkTests/CompactBlockProcessorTests.swift
+++ b/Tests/NetworkTests/CompactBlockProcessorTests.swift
@@ -20,7 +20,7 @@ class CompactBlockProcessorTests: XCTestCase {
             spendParamsURL: pathProvider.spendParamsURL,
             outputParamsURL: pathProvider.outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight,
+            walletBirthdayProvider: { ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight },
             network: ZcashNetworkBuilder.network(for: .testnet)
         )
     }()

--- a/Tests/NetworkTests/CompactBlockReorgTests.swift
+++ b/Tests/NetworkTests/CompactBlockReorgTests.swift
@@ -20,7 +20,7 @@ class CompactBlockReorgTests: XCTestCase {
             spendParamsURL: pathProvider.spendParamsURL,
             outputParamsURL: pathProvider.outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight,
+            walletBirthdayProvider: { ZcashNetworkBuilder.network(for: .testnet).constants.saplingActivationHeight },
             network: ZcashNetworkBuilder.network(for: .testnet)
         )
     }()

--- a/Tests/OfflineTests/BlockBatchValidationTests.swift
+++ b/Tests/OfflineTests/BlockBatchValidationTests.swift
@@ -60,7 +60,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: 1210000,
+            walletBirthdayProvider: { 1210000 },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -130,7 +130,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: 1210000,
+            walletBirthdayProvider: { 1210000 },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -200,7 +200,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: 1210000,
+            walletBirthdayProvider: { 1210000 },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -270,7 +270,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: 1210000,
+            walletBirthdayProvider: { 1210000 },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -338,7 +338,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: 1210000,
+            walletBirthdayProvider: { 1210000 },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -430,7 +430,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: walletBirthday,
+            walletBirthdayProvider: { walletBirthday },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )
@@ -511,7 +511,7 @@ class BlockBatchValidationTests: XCTestCase {
             retries: 5,
             maxBackoffInterval: 10,
             rewindDistance: 100,
-            walletBirthday: walletBirthday,
+            walletBirthdayProvider: { walletBirthday },
             saplingActivation: network.constants.saplingActivationHeight,
             network: network
         )

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -52,14 +52,12 @@ class WalletTests: XCTestCase {
             network: network,
             spendParamsURL: try __spendParamsURL(),
             outputParamsURL: try __outputParamsURL(),
-            saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            viewingKeys: [ufvk],
-            walletBirthday: 663194
+            saplingParamsSourceURL: SaplingParamsSourceURL.tests
         )
         
-        let synchronizer = try SDKSynchronizer(initializer: wallet)
+        let synchronizer = SDKSynchronizer(initializer: wallet)
         do {
-            guard case .success = try synchronizer.prepare(with: seedData.bytes) else {
+            guard case .success = try synchronizer.prepare(with: seedData.bytes, viewingKeys: [ufvk], walletBirthday: 663194) else {
                 XCTFail("Failed to initDataDb. Expected `.success` got: `.seedRequired`")
                 return
             }

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -59,8 +59,6 @@ class SynchronizerTests: XCTestCase {
                 spendParamsURL: try __spendParamsURL(),
                 outputParamsURL: try __outputParamsURL(),
                 saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-                viewingKeys: [ufvk],
-                walletBirthday: birthday,
                 alias: "",
                 loggerProxy: OSLogger(logLevel: .debug)
             )
@@ -69,8 +67,8 @@ class SynchronizerTests: XCTestCase {
             try? FileManager.default.removeItem(at: databases.dataDB)
             try? FileManager.default.removeItem(at: databases.pendingDB)
             
-            let synchronizer = try SDKSynchronizer(initializer: initializer)
-            _ = try synchronizer.prepare(with: seedBytes)
+            let synchronizer = SDKSynchronizer(initializer: initializer)
+            _ = try synchronizer.prepare(with: seedBytes, viewingKeys: [ufvk], walletBirthday: birthday)
             
             let syncSyncedExpectation = XCTestExpectation(description: "synchronizerSynced Expectation")
             syncSyncedExpectation.subscribe(to: .synchronizerSynced, object: nil)

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -416,7 +416,7 @@ extension CompactBlockProcessor.Configuration {
             spendParamsURL: pathProvider.spendParamsURL,
             outputParamsURL: pathProvider.outputParamsURL,
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
-            walletBirthday: walletBirthday,
+            walletBirthdayProvider: { walletBirthday },
             network: network
         )
     }

--- a/Tests/TestUtils/TestDbBuilder.swift
+++ b/Tests/TestUtils/TestDbBuilder.swift
@@ -65,7 +65,7 @@ enum TestDbBuilder {
 
         let initResult = try ZcashRustBackend.initDataDb(
             dbData: url,
-            seed: TestSeed().seed(),
+            seed: Environment.seedBytes,
             networkType: .mainnet
         )
         

--- a/Tests/TestUtils/Tests+Utils.swift
+++ b/Tests/TestUtils/Tests+Utils.swift
@@ -19,6 +19,13 @@ enum Environment {
     still champion voice habit trend flight survey between bitter process artefact blind carbon truly provide dizzy crush flush breeze blouse charge \
     solid fish spread
     """
+
+    // Seed bytes for `seedPhrase`.
+    static var seedBytes: [UInt8] {
+        let seedString = Data(base64Encoded: "9VDVOZZZOWWHpZtq1Ebridp3Qeux5C+HwiRR0g7Oi7HgnMs8Gfln83+/Q1NnvClcaSwM4ADFL1uZHxypEWlWXg==")!
+        return [UInt8](seedString)
+    }
+
     static let testRecipientAddress = "zs17mg40levjezevuhdp5pqrd52zere7r7vrjgdwn5sj4xsqtm20euwahv9anxmwr3y3kmwuz8k55a"
 }
 
@@ -135,15 +142,4 @@ func parametersReady() -> Bool {
     }
 
     return true
-}
-
-class TestSeed {
-    /**
-    test account: "still champion voice habit trend flight survey between bitter process artefact blind carbon truly provide dizzy crush flush breeze blouse charge solid fish spread"
-    */
-    let seedString = Data(base64Encoded: "9VDVOZZZOWWHpZtq1Ebridp3Qeux5C+HwiRR0g7Oi7HgnMs8Gfln83+/Q1NnvClcaSwM4ADFL1uZHxypEWlWXg==")!
-    
-    func seed() -> [UInt8] {
-        [UInt8](seedString)
-    }
 }


### PR DESCRIPTION
Closes #826

- `viewingKeys` and `walletBirthday` are removed from `Initializer` constuctor. These parameters are moved to `SDKSynchronizer.prepare` function.
- Constructor of the `SDKSynchronizer` no longer throws exception.
- Any value emitted from `lastState` stream before `SDKSynchronizer.prepare` is called has `latestScannedHeight` set to 0.
- `Initializer.initialize` function isn't public anymore. To initialize SDK call `SDKSynchronizer.prepare` instead.
- Real birthday is now known after the `SDKSynchronizer.prepare` is called. But this function isn't async and therefore it's hard to pass birthday from here to `CompactBlockProcessor` in synchronous manner. We must be sure that it's safe to call start() after prepare function finishes.
        For this reason `CompactBlockProcessor` has `walletBirthdayProvider` instead of `walletBirthday`. And this new parameter is closure which reads birthday from `Initiliazer` on each call. Thanks to this `CompactBlockProcessor` has always the right birthday.
- Some cleanup is done in `TestCoordinator`.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.