### PR TITLE
[#724] Switch from NotificationCenter to Combine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # unreleased 
+- [#724] Switch from event based notifications to state based notifications
+
+    The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.
+Notifications are replaced with `Combine` publishers. Check the migrating document and
+documentation in the code to get more information.
+
 - [#826] Change how the SDK is initialized
     
     - `viewingKeys` and `walletBirthday` are removed from `Initializer` constuctor. These parameters

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,4 +1,32 @@
-# Migrating from previous versions to <Unreleased>
+# Migrating from previous versions to <unreleased>
+The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.
+Notifications are replaced with `Combine` publishers.
+
+`stateStream` publisher replaces notifications related to `SyncStatus` changes.
+These notifications are replaced by `stateStream`:
+- .synchronizerStarted
+- .synchronizerProgressUpdated
+- .synchronizerStatusWillUpdate
+- .synchronizerSynced
+- .synchronizerStopped
+- .synchronizerDisconnected
+- .synchronizerSyncing
+- .synchronizerEnhancing
+- .synchronizerFetching
+- .synchronizerFailed
+
+`eventStream` publisher replaces notifications related to transactions and other stuff.
+These notifications are replaced by `eventStream`:
+- .synchronizerMinedTransaction
+- .synchronizerFoundTransactions
+- .synchronizerStoredUTXOs
+- .synchronizerConnectionStateChanged
+
+`latestState` is also new property that can be used to get the latest SDK state in a synchronous way.
+`SDKSynchronizer.status` is no longer public. To get `SyncStatus` either subscribe to `stateStream` 
+or use `latestState`. 
+
+# Migrating from previous versions to 0.18.x
 Compact block cache no longer uses a sqlite database. The existing database
 should be deleted. `Initializer` now takes an `fsBlockDbRootURL` which is a 
 URL pointing to a RW directory in the filesystem that will be used to store

--- a/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
+++ b/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
@@ -20,7 +20,7 @@ struct BlockEnhancerConfig {
 }
 
 protocol BlockEnhancer {
-    func enhance(at range: CompactBlockRange, didEnhance: (EnhancementStreamProgress) async -> Void) async throws -> [ZcashTransaction.Overview]
+    func enhance(at range: CompactBlockRange, didEnhance: (EnhancementProgress) async -> Void) async throws -> [ZcashTransaction.Overview]
 }
 
 struct BlockEnhancerImpl {
@@ -75,7 +75,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
         case txIdNotFound(txId: Data)
     }
 
-    func enhance(at range: CompactBlockRange, didEnhance: (EnhancementStreamProgress) async -> Void) async throws -> [ZcashTransaction.Overview] {
+    func enhance(at range: CompactBlockRange, didEnhance: (EnhancementProgress) async -> Void) async throws -> [ZcashTransaction.Overview] {
         try Task.checkCancellation()
         
         LoggerProxy.debug("Started Enhancing range: \(range)")
@@ -103,7 +103,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
                     do {
                         let confirmedTx = try await enhance(transaction: transaction)
                         retry = false
-                        let progress = EnhancementStreamProgress(
+                        let progress = EnhancementProgress(
                             totalTransactions: transactions.count,
                             enhancedTransactions: index + 1,
                             lastFoundTransaction: confirmedTx,

--- a/Tests/TestUtils/SDKSynchronizerSyncStatusHandler.swift
+++ b/Tests/TestUtils/SDKSynchronizerSyncStatusHandler.swift
@@ -1,0 +1,50 @@
+//
+//  SDKSynchronizerStateHandler.swift
+//  
+//
+//  Created by Michal Fousek on 15.03.2023.
+//
+
+import Combine
+import Foundation
+import XCTest
+@testable import ZcashLightClientKit
+
+class SDKSynchronizerSyncStatusHandler {
+    enum StatusIdentifier: String {
+        case unprepared
+        case syncing
+        case enhancing
+        case fetching
+        case synced
+        case stopped
+        case disconnected
+        case error
+    }
+
+    private let queue = DispatchQueue(label: "SDKSynchronizerSyncStatusHandler")
+    private var cancellables: [AnyCancellable] = []
+
+    func subscribe(to stateStream: AnyPublisher<SynchronizerState, Never>, expectations: [StatusIdentifier: XCTestExpectation]) {
+        stateStream
+            .receive(on: queue)
+            .map { $0.syncStatus }
+            .sink { status in expectations[status.identifier]?.fulfill() }
+            .store(in: &cancellables)
+    }
+}
+
+extension SyncStatus {
+    var identifier: SDKSynchronizerSyncStatusHandler.StatusIdentifier {
+        switch self {
+        case .unprepared: return .unprepared
+        case .syncing: return .syncing
+        case .enhancing: return .enhancing
+        case .fetching: return .fetching
+        case .synced: return .synced
+        case .stopped: return .stopped
+        case .disconnected: return .disconnected
+        case .error: return .error
+        }
+    }
+}

--- a/Tests/TestUtils/Tests+Utils.swift
+++ b/Tests/TestUtils/Tests+Utils.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Electric Coin Company. All rights reserved.
 //
 
+import Combine
 import Foundation
 import GRPC
 import ZcashLightClientKit
@@ -76,20 +77,6 @@ enum MockDbInit {
     
     static func destroy(at path: String) throws {
         try FileManager.default.removeItem(atPath: path)
-    }
-}
-
-extension XCTestExpectation {
-    func subscribe(to notification: Notification.Name, object: Any?) {
-        NotificationCenter.default.addObserver(self, selector: #selector(fulfill), name: notification, object: object)
-    }
-    
-    func unsubscribe(from notification: Notification.Name) {
-        NotificationCenter.default.removeObserver(self, name: notification, object: nil)
-    }
-    
-    func unsubscribeFromNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 }
 


### PR DESCRIPTION
Closes #724

- All the notifications are gone. Only
  `synchronizerConnectionStateChanged` stayed because it's used
  internally. Let's deal with this one in another task.
- Synchronizer has now two new publishers (`stateStream` and
  (`eventStream`) which are used to notify the client app about
  what is going on. These publishers replace notifications.
- There is also new property `latestState` which can be used to get the
  SDK state in synchronous manner.
- `SDKSynchronizer.status` is no longer public. It is used internally to
  refresh `latestState` and emit new values from `stateStream`.
- When `SDKSynchronizer.status` is update `notify()` function is
  triggered. And this function is now responsible for generating new
  snapshot of `SynchronizerState` and updating `latestState` and
  `stateStream`.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.