### PR TITLE
[#831] Use async inside of the SDKSynchronizer

### DIFF
--- a/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
@@ -11,7 +11,7 @@ class AfterSyncHooksManager {
     struct WipeContext {
         let pendingDbURL: URL
         let prewipe: () -> Void
-        let completion: (Error?) -> Void
+        let completion: (Error?) async -> Void
     }
 
     struct RewindContext {

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -330,6 +330,19 @@ public enum SyncStatus: Equatable {
         default:        return false
         }
     }
+
+    public var briefDebugDescription: String {
+        switch self {
+        case .unprepared: return "unprepared"
+        case .syncing: return "syncing"
+        case .enhancing: return "enhancing"
+        case .fetching: return "fetching"
+        case .synced: return "synced"
+        case .stopped: return "stopped"
+        case .disconnected: return "disconnected"
+        case .error: return "error"
+        }
+    }
 }
 
 /// Kind of transactions handled by a Synchronizer

--- a/Sources/ZcashLightClientKit/Utils/GenericActor.swift
+++ b/Sources/ZcashLightClientKit/Utils/GenericActor.swift
@@ -1,0 +1,18 @@
+//
+//  GenericActor.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Foundation
+
+actor GenericActor<T> {
+    var value: T
+    init(_ value: T) { self.value = value }
+    func update(_ newValue: T) async -> T {
+        let oldValue = value
+        value = newValue
+        return oldValue
+    }
+}

--- a/Tests/DarksideTests/AdvancedReOrgTests.swift
+++ b/Tests/DarksideTests/AdvancedReOrgTests.swift
@@ -1330,13 +1330,13 @@ class AdvancedReOrgTests: XCTestCase {
     }
     
     func hookToReOrgNotification() async {
-        await coordinator.synchronizer.blockProcessor.eventStream
-            .sink { [weak self] event in
-                switch event {
-                case .handledReorg: self?.handleReorg(event: event)
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .handledReorg: self?.handleReorg(event: event)
+            default: break
             }
-            .store(in: &cancellables)
+        }
+
+        await coordinator.synchronizer.blockProcessor.updateEventClosure(identifier: "tests", closure: eventClosure)
     }
 }

--- a/Tests/DarksideTests/InternalStateConsistencyTests.swift
+++ b/Tests/DarksideTests/InternalStateConsistencyTests.swift
@@ -77,8 +77,10 @@ final class InternalStateConsistencyTests: XCTestCase {
 
         wait(for: [firstSyncExpectation], timeout: 2)
 
-        XCTAssertFalse(coordinator.synchronizer.status.isSyncing)
-        XCTAssertEqual(coordinator.synchronizer.status, .stopped)
+        let isSyncing = await coordinator.synchronizer.status.isSyncing
+        let status = await coordinator.synchronizer.status
+        XCTAssertFalse(isSyncing, "SDKSynchronizer shouldn't be syncing")
+        XCTAssertEqual(status, .stopped)
 
         let internalSyncState = InternalSyncProgress(storage: UserDefaults.standard)
 

--- a/Tests/DarksideTests/ReOrgTests.swift
+++ b/Tests/DarksideTests/ReOrgTests.swift
@@ -50,16 +50,14 @@ class ReOrgTests: XCTestCase {
 
         try self.coordinator.resetBlocks(dataset: .default)
 
-        var stream: AnyPublisher<CompactBlockProcessor.Event, Never>!
-        XCTestCase.wait { await stream = self.coordinator.synchronizer.blockProcessor.eventStream }
-        stream
-            .sink { [weak self] event in
-                switch event {
-                case .handledReorg: self?.handleReOrgNotification(event: event)
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .handledReorg: self?.handleReOrgNotification(event: event)
+            default: break
             }
-            .store(in: &cancellables)
+        }
+
+        XCTestCase.wait { await self.coordinator.synchronizer.blockProcessor.updateEventClosure(identifier: "tests", closure: eventClosure) }
     }
 
     override func tearDownWithError() throws {

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -131,16 +131,14 @@ class TransactionEnhancementTests: XCTestCase {
             config: processorConfig
         )
 
-        var stream: AnyPublisher<CompactBlockProcessor.Event, Never>!
-        XCTestCase.wait { await stream = self.processor.eventStream }
-        stream
-            .sink { [weak self] event in
-                switch event {
-                case .failed: self?.processorFailed(event: event)
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .failed: self?.processorFailed(event: event)
+            default: break
             }
-            .store(in: &cancellables)
+        }
+
+        XCTestCase.wait { await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure) }
     }
     
     override func tearDownWithError() throws {
@@ -167,8 +165,8 @@ class TransactionEnhancementTests: XCTestCase {
             .foundTransactions: txFoundNotificationExpectation,
             .finished: finishedNotificationExpectation
         ]
-        processorEventHandler.subscribe(to: await processor.eventStream, expectations: expectations)
 
+        await processorEventHandler.subscribe(to: processor, expectations: expectations)
         await processor.start()
     }
     

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -197,14 +197,14 @@ class BlockScanTests: XCTestCase {
             config: processorConfig
         )
 
-        await compactBlockProcessor.eventStream
-            .sink { [weak self] event in
-                switch event {
-                case .progressUpdated: self?.observeBenchmark()
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .progressUpdated: self?.observeBenchmark()
+            default: break
             }
-            .store(in: &cancelables)
+        }
+
+        await compactBlockProcessor.updateEventClosure(identifier: "tests", closure: eventClosure)
 
         let range = CompactBlockRange(
             uncheckedBounds: (walletBirthDay.height, walletBirthDay.height + 10000)

--- a/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
+++ b/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
@@ -27,11 +27,12 @@ class CompactBlockProcessorEventHandler {
     private let queue = DispatchQueue(label: "CompactBlockProcessorEventHandler")
     private var cancelables: [AnyCancellable] = []
 
-    func subscribe(to eventStream: AnyPublisher<CompactBlockProcessor.Event, Never>, expectations: [EventIdentifier: XCTestExpectation]) {
-        eventStream
-            .receive(on: queue)
-            .sink { event in expectations[event.identifier]?.fulfill() }
-            .store(in: &cancelables)
+    func subscribe(to blockProcessor: CompactBlockProcessor, expectations: [EventIdentifier: XCTestExpectation]) async {
+        let closure: CompactBlockProcessor.EventClosure = { event in
+            expectations[event.identifier]?.fulfill()
+        }
+
+        await blockProcessor.updateEventClosure(identifier: "CompactBlockProcessorEventHandler", closure: closure)
     }
 }
 


### PR DESCRIPTION
- In general lot of methods inside the `SDKSynchronizer` and `CompactBlockProcessoer` which weren't async are now async. And other changes are made because of this change.
- `CompactBlockProcessor` no longer uses Combine to communicate with `SDKSynchronizer`. Reason for this is that Combine doesn't play great with async. Closure passed to `sink` isn't async.
- Because of this and because of how our tests work (receiving signals from CBP directly) `CompactBlockProcessor` must be able to handle more event closures. Not just one. So it now has `eventClosures` dictionary. It's little bit strange but it works fine.
- `SyncStatus` inside the `SDKSynchronizer` was previously protected by lock. Now it's protected by simple actor wrapper.
- Changes in tests are minimal. Changes were mady only because `CompactBlockProcessor` changes from Combine to closures.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [x] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [x] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.