### PR TITLE
[#831] Add SDKSynchronizer wrappers for non-async API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # unreleased 
+- [#831] Add support for alternative APIs
+
+    There are two new protocols (`ClosureSynchronizer` and `CombineSynchronizer`). And there are two new 
+objects which conform to respective protocols (`ClosureSDKSynchronizer` and `CombineSDKSynchronizer`). These
+new objects offer alternative API for the `SDKSynchronizer`. Now the client app can choose which technology 
+it wants to use to communicate with Zcash SDK and it isn't forced to use async.
+
+These methods in the `SDKSynchronizer` are now async:
+- `prepare(with:viewingKeys:walletBirthday:)`
+- `start(retry:)`
+- `stop()`
+
+Non async `SDKsynchronizer.latestHeight(result:)` were moved to `ClosureSDKSynchronizer`.
+
 - [#724] Switch from event based notifications to state based notifications
 
     The `SDKSynchronizer` no longer uses `NotificationCenter` to send notifications.

--- a/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
+++ b/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
@@ -15,7 +15,7 @@ enum UTXOFetcherError: Error {
 struct UTXOFetcherConfig {
     let dataDb: URL
     let networkType: NetworkType
-    let walletBirthdayProvider: () -> BlockHeight
+    let walletBirthdayProvider: () async -> BlockHeight
 }
 
 protocol UTXOFetcher {
@@ -48,7 +48,7 @@ extension UTXOFetcherImpl: UTXOFetcher {
         var utxos: [UnspentTransactionOutputEntity] = []
         let stream: AsyncThrowingStream<UnspentTransactionOutputEntity, Error> = blockDownloaderService.fetchUnspentTransactionOutputs(
             tAddresses: tAddresses.map { $0.stringEncoded },
-            startHeight: config.walletBirthdayProvider()
+            startHeight: await config.walletBirthdayProvider()
         )
 
         for try await transaction in stream {

--- a/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
@@ -11,7 +11,7 @@ class AfterSyncHooksManager {
     struct WipeContext {
         let pendingDbURL: URL
         let prewipe: () -> Void
-        let completion: (Error?) -> Void
+        let completion: (Error?) async -> Void
     }
 
     struct RewindContext {

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -1,0 +1,90 @@
+//
+//  ClosureSynchronizer.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Combine
+import Foundation
+
+/// This defines closure-based API for the SDK. It's expected that the implementation of this protocol is only a very thin layer that translates async
+/// API defined in `Synchronizer` to closure-based API. And it doesn't do anything else. It's here so each client can choose the API that suits its
+/// case the best.
+///
+/// If you are looking for documentation for a specific method or property look for it in the `Synchronizer` protocol.
+public protocol ClosureSynchronizer {
+    var latestState: SynchronizerState { get }
+    var connectionState: ConnectionState { get }
+
+    var stateStream: AnyPublisher<SynchronizerState, Never> { get }
+    var eventStream: AnyPublisher<SynchronizerEvent, Never> { get }
+
+    func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight,
+        completion: @escaping (Result<Initializer.InitializationResult, Error>) -> Void
+    )
+
+    func start(retry: Bool, completion: @escaping (Error?) -> Void)
+    func stop(completion: @escaping () -> Void)
+
+    func getSaplingAddress(accountIndex: Int, completion: @escaping (SaplingAddress?) -> Void)
+    func getUnifiedAddress(accountIndex: Int, completion: @escaping (UnifiedAddress?) -> Void)
+    func getTransparentAddress(accountIndex: Int, completion: @escaping (TransparentAddress?) -> Void)
+
+    func sendToAddress(
+        spendingKey: UnifiedSpendingKey,
+        zatoshi: Zatoshi,
+        toAddress: Recipient,
+        memo: Memo?,
+        completion: @escaping (Result<PendingTransactionEntity, Error>) -> Void
+    )
+
+    func shieldFunds(
+        spendingKey: UnifiedSpendingKey,
+        memo: Memo,
+        shieldingThreshold: Zatoshi,
+        completion: @escaping (Result<PendingTransactionEntity, Error>) -> Void
+    )
+
+    func cancelSpend(transaction: PendingTransactionEntity) -> Bool
+
+    var pendingTransactions: [PendingTransactionEntity] { get }
+    var clearedTransactions: [ZcashTransaction.Overview] { get }
+    var sentTransactions: [ZcashTransaction.Sent] { get }
+    var receivedTransactions: [ZcashTransaction.Received] { get }
+    
+    func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository
+
+    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
+
+    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient]
+
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
+
+    func latestHeight(completion: @escaping (Result<BlockHeight, Error>) -> Void)
+
+    func refreshUTXOs(address: TransparentAddress, from height: BlockHeight, completion: @escaping (Result<RefreshedUTXOs, Error>) -> Void)
+
+    func getTransparentBalance(accountIndex: Int, completion: @escaping (Result<WalletBalance, Error>) -> Void)
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    func getShieldedBalance(accountIndex: Int) -> Int64
+    func getShieldedBalance(accountIndex: Int) -> Zatoshi
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Int64
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi
+
+    /*
+     It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
+     provide different implementations for these two methods. So Combine it is even here.
+     */
+    func rewind(_ policy: RewindPolicy) -> Completable<Error>
+    func wipe() -> Completable<Error>
+}

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -1,0 +1,90 @@
+//
+//  CombineSynchronizer.swift
+//  
+//
+//  Created by Michal Fousek on 16.03.2023.
+//
+
+import Combine
+import Foundation
+
+/* These aliases are here to just make the API easier to read. */
+
+// Publisher which emitts completed or error. No value is emitted.
+public typealias Completable<E: Error> = AnyPublisher<Void, E>
+// Publisher that either emits one value and then finishes or it emits error.
+public typealias Single = AnyPublisher
+
+/// This defines a Combine-based API for the SDK. It's expected that the implementation of this protocol is only a very thin layer that translates
+/// async API defined in `Synchronizer` to Combine-based API. And it doesn't do anything else. It's here so each client can choose the API that suits
+/// its case the best.
+///
+/// If you are looking for documentation for a specific method or property look for it in the `Synchronizer` protocol.
+public protocol CombineSynchronizer {
+    var latestState: SynchronizerState { get }
+    var connectionState: ConnectionState { get }
+
+    var stateStream: AnyPublisher<SynchronizerState, Never> { get }
+    var eventStream: AnyPublisher<SynchronizerEvent, Never> { get }
+
+    func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight
+    ) -> Single<Initializer.InitializationResult, Error>
+
+    func start(retry: Bool) -> Completable<Error>
+    func stop() -> Completable<Never>
+
+    func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress?, Never>
+    func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress?, Never>
+    func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress?, Never>
+
+    func sendToAddress(
+        spendingKey: UnifiedSpendingKey,
+        zatoshi: Zatoshi,
+        toAddress: Recipient,
+        memo: Memo?
+    ) -> Single<PendingTransactionEntity, Error>
+
+    func shieldFunds(
+        spendingKey: UnifiedSpendingKey,
+        memo: Memo,
+        shieldingThreshold: Zatoshi
+    ) -> Single<PendingTransactionEntity, Error>
+
+    func cancelSpend(transaction: PendingTransactionEntity) -> Bool
+
+    var pendingTransactions: [PendingTransactionEntity] { get }
+    var clearedTransactions: [ZcashTransaction.Overview] { get }
+    var sentTransactions: [ZcashTransaction.Sent] { get }
+    var receivedTransactions: [ZcashTransaction.Received] { get }
+    
+    func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository
+
+    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
+
+    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient]
+
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
+
+    func latestHeight() -> Single<BlockHeight, Error>
+
+    func refreshUTXOs(address: TransparentAddress, from height: BlockHeight) -> Single<RefreshedUTXOs, Error>
+
+    func getTransparentBalance(accountIndex: Int) -> Single<WalletBalance, Error>
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    func getShieldedBalance(accountIndex: Int) -> Int64
+    func getShieldedBalance(accountIndex: Int) -> Zatoshi
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Int64
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi
+
+    func rewind(_ policy: RewindPolicy) -> Completable<Error>
+    func wipe() -> Completable<Error>
+}

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -95,7 +95,13 @@ public enum SynchronizerEvent {
 
 /// Primary interface for interacting with the SDK. Defines the contract that specific
 /// implementations like SdkSynchronizer fulfill.
-public protocol Synchronizer {
+public protocol Synchronizer: AnyObject {
+    /// Latest state of the SDK which can be get in synchronous manner.
+    var latestState: SynchronizerState { get }
+
+    /// reflects current connection state to LightwalletEndpoint
+    var connectionState: ConnectionState { get }
+
     /// This stream is backed by `CurrentValueSubject`. This is primary source of information about what is the SDK doing. New values are emitted when
     /// `SyncStatus` is changed inside the SDK.
     ///
@@ -103,14 +109,8 @@ public protocol Synchronizer {
     /// delivered. Values are delivered on random background thread.
     var stateStream: AnyPublisher<SynchronizerState, Never> { get }
 
-    /// Latest state of the SDK which can be get in synchronous manner.
-    var latestState: SynchronizerState { get }
-
     /// This stream is backed by `PassthroughSubject`. Check `SynchronizerEvent` to see which events may be emitted.
     var eventStream: AnyPublisher<SynchronizerEvent, Never> { get }
-
-    /// reflects current connection state to LightwalletEndpoint
-    var connectionState: ConnectionState { get }
 
     /// Initialize the wallet. The ZIP-32 seed bytes can optionally be passed to perform
     /// database migrations. most of the times the seed won't be needed. If they do and are
@@ -132,16 +132,16 @@ public protocol Synchronizer {
         with seed: [UInt8]?,
         viewingKeys: [UnifiedFullViewingKey],
         walletBirthday: BlockHeight
-    ) throws -> Initializer.InitializationResult
+    ) async throws -> Initializer.InitializationResult
 
     /// Starts this synchronizer within the given scope.
     ///
     /// Implementations should leverage structured concurrency and
     /// cancel all jobs when this scope completes.
-    func start(retry: Bool) throws
+    func start(retry: Bool) async throws
 
     /// Stop this synchronizer. Implementations should ensure that calling this method cancels all jobs that were created by this instance.
-    func stop() throws
+    func stop() async
 
     /// Gets the sapling shielded address for the given account.
     /// - Parameter accountIndex: the optional accountId whose address is of interest. By default, the first account is used.
@@ -228,9 +228,6 @@ public protocol Synchronizer {
     ///     - limit: the maximum amount of items this should return if available
     ///     - Returns: an array with the given Transactions or nil
     func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
-
-    /// Returns the latest block height from the provided Lightwallet endpoint
-    func latestHeight(result: @escaping (Result<BlockHeight, Error>) -> Void)
 
     /// Returns the latest block height from the provided Lightwallet endpoint
     /// Blocking
@@ -331,6 +328,19 @@ public enum SyncStatus: Equatable {
         switch self {
         case .synced:   return true
         default:        return false
+        }
+    }
+
+    public var briefDebugDescription: String {
+        switch self {
+        case .unprepared: return "unprepared"
+        case .syncing: return "syncing"
+        case .enhancing: return "enhancing"
+        case .fetching: return "fetching"
+        case .synced: return "synced"
+        case .stopped: return "stopped"
+        case .disconnected: return "disconnected"
+        case .error: return "error"
         }
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -1,0 +1,186 @@
+//
+//  ClosureSDKSynchronizer.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Combine
+import Foundation
+
+/// This is a super thin layer that implements the `ClosureSynchronizer` protocol and translates the async API defined in `Synchronizer` to
+/// closure-based API. And it doesn't do anything else. It doesn't keep any state.  It's here so each client can choose the API that suits its case
+/// the best. And usage of this can be combined with usage of `CombineSDKSynchronizer`. So devs can really choose the best SDK API for each part of the
+/// client app.
+///
+/// If you are looking for documentation for a specific method or property look for it in the `Synchronizer` protocol.
+public struct ClosureSDKSynchronizer {
+    private let synchronizer: Synchronizer
+
+    public init(synchronizer: Synchronizer) {
+        self.synchronizer = synchronizer
+    }
+}
+
+extension ClosureSDKSynchronizer: ClosureSynchronizer {
+    public var latestState: SynchronizerState { synchronizer.latestState }
+    public var connectionState: ConnectionState { synchronizer.connectionState }
+
+    public var stateStream: AnyPublisher<SynchronizerState, Never> { synchronizer.stateStream }
+    public var eventStream: AnyPublisher<SynchronizerEvent, Never> { synchronizer.eventStream }
+
+    public func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight,
+        completion: @escaping (Result<Initializer.InitializationResult, Error>) -> Void
+    ) {
+        executeThrowingAction(completion) {
+            return try await self.synchronizer.prepare(with: seed, viewingKeys: viewingKeys, walletBirthday: walletBirthday)
+        }
+    }
+
+    public func start(retry: Bool, completion: @escaping (Error?) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.start(retry: retry)
+        }
+    }
+
+    public func stop(completion: @escaping () -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.stop()
+        }
+    }
+
+    public func getSaplingAddress(accountIndex: Int, completion: @escaping (SaplingAddress?) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func getUnifiedAddress(accountIndex: Int, completion: @escaping (UnifiedAddress?) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func getTransparentAddress(accountIndex: Int, completion: @escaping (TransparentAddress?) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func sendToAddress(
+        spendingKey: UnifiedSpendingKey,
+        zatoshi: Zatoshi,
+        toAddress: Recipient,
+        memo: Memo?,
+        completion: @escaping (Result<PendingTransactionEntity, Error>) -> Void
+    ) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.sendToAddress(spendingKey: spendingKey, zatoshi: zatoshi, toAddress: toAddress, memo: memo)
+        }
+    }
+
+    public func shieldFunds(
+        spendingKey: UnifiedSpendingKey,
+        memo: Memo,
+        shieldingThreshold: Zatoshi,
+        completion: @escaping (Result<PendingTransactionEntity, Error>) -> Void
+    ) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.shieldFunds(spendingKey: spendingKey, memo: memo, shieldingThreshold: shieldingThreshold)
+        }
+    }
+
+    public func cancelSpend(transaction: PendingTransactionEntity) -> Bool { synchronizer.cancelSpend(transaction: transaction) }
+
+    public var pendingTransactions: [PendingTransactionEntity] { synchronizer.pendingTransactions }
+    public var clearedTransactions: [ZcashTransaction.Overview] { synchronizer.clearedTransactions }
+    public var sentTransactions: [ZcashTransaction.Sent] { synchronizer.sentTransactions }
+    public var receivedTransactions: [ZcashTransaction.Received] { synchronizer.receivedTransactions }
+    
+    public func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository { synchronizer.paginatedTransactions(of: kind) }
+
+    public func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] { try synchronizer.getMemos(for: transaction) }
+    public func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] { try synchronizer.getMemos(for: receivedTransaction) }
+    public func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] { try synchronizer.getMemos(for: sentTransaction) }
+
+    public func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+    public func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+
+    public func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
+        try synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+    }
+
+    public func latestHeight(completion: @escaping (Result<BlockHeight, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.latestHeight()
+        }
+    }
+
+    public func refreshUTXOs(address: TransparentAddress, from height: BlockHeight, completion: @escaping (Result<RefreshedUTXOs, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.refreshUTXOs(address: address, from: height)
+        }
+    }
+
+    public func getTransparentBalance(accountIndex: Int, completion: @escaping (Result<WalletBalance, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getTransparentBalance(accountIndex: accountIndex)
+        }
+    }
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    public func getShieldedBalance(accountIndex: Int) -> Int64 { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+    public func getShieldedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    public func getShieldedVerifiedBalance(accountIndex: Int) -> Int64 { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+    public func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+
+    /*
+     It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't
+     provide different implementations for these two methods. So Combine it is even here.
+     */
+    public func rewind(_ policy: RewindPolicy) -> Completable<Error> { synchronizer.rewind(policy) }
+    public func wipe() -> Completable<Error> { synchronizer.wipe() }
+}
+
+extension ClosureSDKSynchronizer {
+    private func executeAction(_ completion: @escaping () -> Void, action: @escaping () async -> Void) {
+        Task {
+            await action()
+            completion()
+        }
+    }
+
+    private func executeAction<R>(_ completion: @escaping (R) -> Void, action: @escaping () async -> R) {
+        Task {
+            let result = await action()
+            completion(result)
+        }
+    }
+
+    private func executeThrowingAction(_ completion: @escaping (Error?) -> Void, action: @escaping () async throws -> Void) {
+        Task {
+            do {
+                try await action()
+                completion(nil)
+            } catch {
+                completion(error)
+            }
+        }
+    }
+
+    private func executeThrowingAction<R>(_ completion: @escaping (Result<R, Error>) -> Void, action: @escaping () async throws -> R) {
+        Task {
+            do {
+                let result = try await action()
+                completion(.success(result))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -1,0 +1,191 @@
+//
+//  CombineSDKSynchronizer.swift
+//  
+//
+//  Created by Michal Fousek on 16.03.2023.
+//
+
+import Combine
+import Foundation
+
+/// This is a super thin layer that implements the `CombineSynchronizer` protocol and translates the async API defined in `Synchronizer` to
+/// Combine-based API. And it doesn't do anything else. It doesn't keep any state. It's here so each client can choose the API that suits its case the
+/// best. And usage of this can be combined with usage of `ClosureSDKSynchronizer`. So devs can really choose the best SDK API for each part of the
+/// client app.
+///
+/// If you are looking for documentation for a specific method or property look for it in the `Synchronizer` protocol.
+public struct CombineSDKSynchronizer {
+    private let synchronizer: Synchronizer
+
+    public init(synchronizer: Synchronizer) {
+        self.synchronizer = synchronizer
+    }
+}
+
+extension CombineSDKSynchronizer: CombineSynchronizer {
+    public var latestState: SynchronizerState { synchronizer.latestState }
+    public var connectionState: ConnectionState { synchronizer.connectionState }
+
+    public var stateStream: AnyPublisher<SynchronizerState, Never> { synchronizer.stateStream }
+    public var eventStream: AnyPublisher<SynchronizerEvent, Never> { synchronizer.eventStream }
+
+    public func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight
+    ) -> Single<Initializer.InitializationResult, Error> {
+        return executeThrowingAction() {
+            return try await self.synchronizer.prepare(with: seed, viewingKeys: viewingKeys, walletBirthday: walletBirthday)
+        }
+    }
+
+    public func start(retry: Bool) -> Completable<Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.start(retry: retry)
+        }
+    }
+
+    public func stop() -> Completable<Never> {
+        return executeAction() {
+            await self.synchronizer.stop()
+        }
+    }
+
+    public func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress?, Never> {
+        return executeAction() {
+            await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress?, Never> {
+        return executeAction() {
+            await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress?, Never> {
+        return executeAction() {
+            await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
+        }
+    }
+
+    public func sendToAddress(
+        spendingKey: UnifiedSpendingKey,
+        zatoshi: Zatoshi,
+        toAddress: Recipient,
+        memo: Memo?
+    ) -> Single<PendingTransactionEntity, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.sendToAddress(spendingKey: spendingKey, zatoshi: zatoshi, toAddress: toAddress, memo: memo)
+        }
+    }
+
+    public func shieldFunds(
+        spendingKey: UnifiedSpendingKey,
+        memo: Memo,
+        shieldingThreshold: Zatoshi
+    ) -> Single<PendingTransactionEntity, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.shieldFunds(spendingKey: spendingKey, memo: memo, shieldingThreshold: shieldingThreshold)
+        }
+    }
+
+    public func cancelSpend(transaction: PendingTransactionEntity) -> Bool { synchronizer.cancelSpend(transaction: transaction) }
+
+    public var pendingTransactions: [PendingTransactionEntity] { synchronizer.pendingTransactions }
+    public var clearedTransactions: [ZcashTransaction.Overview] { synchronizer.clearedTransactions }
+    public var sentTransactions: [ZcashTransaction.Sent] { synchronizer.sentTransactions }
+    public var receivedTransactions: [ZcashTransaction.Received] { synchronizer.receivedTransactions }
+    
+    public func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository { synchronizer.paginatedTransactions(of: kind) }
+
+    public func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] { try synchronizer.getMemos(for: transaction) }
+    public func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] { try synchronizer.getMemos(for: receivedTransaction) }
+    public func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] { try synchronizer.getMemos(for: sentTransaction) }
+
+    public func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+    public func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+
+    public func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
+        try synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+    }
+
+    public func latestHeight() -> Single<BlockHeight, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.latestHeight()
+        }
+    }
+
+    public func refreshUTXOs(address: TransparentAddress, from height: BlockHeight) -> Single<RefreshedUTXOs, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.refreshUTXOs(address: address, from: height)
+        }
+    }
+
+    public func getTransparentBalance(accountIndex: Int) -> Single<WalletBalance, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.getTransparentBalance(accountIndex: accountIndex)
+        }
+    }
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    public func getShieldedBalance(accountIndex: Int) -> Int64 { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+    public func getShieldedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+
+    @available(*, deprecated, message: "This function will be removed soon, use the one returning a `Zatoshi` value instead")
+    public func getShieldedVerifiedBalance(accountIndex: Int) -> Int64 { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+    public func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+
+    public func rewind(_ policy: RewindPolicy) -> Completable<Error> { synchronizer.rewind(policy) }
+    public func wipe() -> Completable<Error> { synchronizer.wipe() }
+}
+
+extension CombineSDKSynchronizer {
+    private func executeAction(action: @escaping () async -> Void) -> Completable<Never> {
+        let subject = PassthroughSubject<Void, Never>()
+        Task {
+            await action()
+            subject.send(completion: .finished)
+        }
+        return subject.eraseToAnyPublisher()
+    }
+
+    private func executeAction<R>(action: @escaping () async -> R) -> Single<R, Never> {
+        let subject = PassthroughSubject<R, Never>()
+        Task {
+            let result = await action()
+            subject.send(result)
+            subject.send(completion: .finished)
+        }
+        return subject.eraseToAnyPublisher()
+    }
+
+    private func executeThrowingAction(action: @escaping () async throws -> Void) -> Completable<Error> {
+        let subject = PassthroughSubject<Void, Error>()
+        Task {
+            do {
+                try await action()
+                subject.send(completion: .finished)
+            } catch {
+                subject.send(completion: .failure(error))
+            }
+        }
+
+        return subject.eraseToAnyPublisher()
+    }
+
+    private func executeThrowingAction<R>(action: @escaping () async throws -> R) -> Single<R, Error> {
+        let subject = PassthroughSubject<R, Error>()
+        Task {
+            do {
+                let result = try await action()
+                subject.send(result)
+                subject.send(completion: .finished)
+            } catch {
+                subject.send(completion: .failure(error))
+            }
+        }
+
+        return subject.eraseToAnyPublisher()
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -29,21 +29,10 @@ public class SDKSynchronizer: Synchronizer {
     private let eventSubject = PassthroughSubject<SynchronizerEvent, Never>()
     public var eventStream: AnyPublisher<SynchronizerEvent, Never> { eventSubject.eraseToAnyPublisher() }
 
-    private let statusUpdateLock = NSRecursiveLock()
-    private var underlyingStatus: SyncStatus
+    // Don't read this variable directly. Use `status` instead. And don't update this variable directly use `updateStatus()` methods instead.
+    private var underlyingStatus: GenericActor<SyncStatus>
     var status: SyncStatus {
-        get {
-            statusUpdateLock.lock()
-            defer { statusUpdateLock.unlock() }
-            return underlyingStatus
-        }
-        set {
-            statusUpdateLock.lock()
-            let oldValue = underlyingStatus
-            underlyingStatus = newValue
-            notify(oldStatus: oldValue, newStatus: newValue)
-            statusUpdateLock.unlock()
-        }
+        get async { await underlyingStatus.value }
     }
 
     let blockProcessor: CompactBlockProcessor
@@ -60,8 +49,6 @@ public class SDKSynchronizer: Synchronizer {
 
     private var syncStartDate: Date?
 
-    private var longLivingCancelables: [AnyCancellable] = []
-    
     /// Creates an SDKSynchronizer instance
     /// - Parameter initializer: a wallet Initializer object
     public convenience init(initializer: Initializer) {
@@ -87,7 +74,7 @@ public class SDKSynchronizer: Synchronizer {
         blockProcessor: CompactBlockProcessor
     ) {
         self.connectionState = .idle
-        self.underlyingStatus = status
+        self.underlyingStatus = GenericActor(status)
         self.initializer = initializer
         self.transactionManager = transactionManager
         self.transactionRepository = transactionRepository
@@ -107,12 +94,17 @@ public class SDKSynchronizer: Synchronizer {
         }
     }
 
+    func updateStatus(_ newValue: SyncStatus) async {
+        let oldValue = await underlyingStatus.update(newValue)
+        await notify(oldStatus: oldValue, newStatus: newValue)
+    }
+
     public func prepare(
         with seed: [UInt8]?,
         viewingKeys: [UnifiedFullViewingKey],
         walletBirthday: BlockHeight
-    ) throws -> Initializer.InitializationResult {
-        guard status == .unprepared else { return .success }
+    ) async throws -> Initializer.InitializationResult {
+        guard await status == .unprepared else { return .success }
 
         try utxoRepository.initialise()
 
@@ -122,45 +114,40 @@ public class SDKSynchronizer: Synchronizer {
 
         latestScannedHeight = (try? transactionRepository.lastScannedHeight()) ?? initializer.walletBirthday
 
-        self.status = .disconnected
+        await updateStatus(.disconnected)
 
         return .success
     }
 
     /// Starts the synchronizer
     /// - Throws: CompactBlockProcessorError when failures occur
-    public func start(retry: Bool = false) throws {
-        switch status {
+    public func start(retry: Bool = false) async throws {
+        switch await status {
         case .unprepared:
             throw SynchronizerError.notPrepared
 
         case .syncing, .enhancing, .fetching:
             LoggerProxy.warn("warning: Synchronizer started when already running. Next sync process will be started when the current one stops.")
-            Task {
-                /// This may look strange but `CompactBlockProcessor` has mechanisms which can handle this situation. So we are fine with calling
-                /// it's start here.
-                await blockProcessor.start(retry: retry)
-            }
+            /// This may look strange but `CompactBlockProcessor` has mechanisms which can handle this situation. So we are fine with calling
+            /// it's start here.
+            await blockProcessor.start(retry: retry)
 
         case .stopped, .synced, .disconnected, .error:
-            Task {
-                status = .syncing(.nullProgress)
-                syncStartDate = Date()
-                await blockProcessor.start(retry: retry)
-            }
+            await updateStatus(.syncing(.nullProgress))
+            syncStartDate = Date()
+            await blockProcessor.start(retry: retry)
         }
     }
 
     /// Stops the synchronizer
-    public func stop() {
+    public func stop() async {
+        let status = await self.status
         guard status != .stopped, status != .disconnected else {
             LoggerProxy.info("attempted to stop when status was: \(status)")
             return
         }
 
-        Task(priority: .high) {
-            await blockProcessor.stop()
-        }
+        await blockProcessor.stop()
     }
 
     private func subscribeToProcessorNotifications(_ processor: CompactBlockProcessor) {
@@ -197,55 +184,52 @@ public class SDKSynchronizer: Synchronizer {
     // MARK: Handle CompactBlockProcessor.Flow
 
     private func subscribeToProcessorEvents(_ processor: CompactBlockProcessor) async {
-        let stream = await processor.eventStream
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case let .failed(error):
+                await self?.failed(error: error)
 
-        stream
-            .receive(on: blockProcessorEventProcessingQueue)
-            .sink { [weak self] event in
-                switch event {
-                case let .failed(error):
-                    self?.failed(error: error)
+            case let .finished(height, foundBlocks):
+                await self?.finished(lastScannedHeight: height, foundBlocks: foundBlocks)
 
-                case let .finished(height, foundBlocks):
-                    self?.finished(lastScannedHeight: height, foundBlocks: foundBlocks)
+            case let .foundTransactions(transactions, range):
+                self?.foundTransactions(transactions: transactions, in: range)
 
-                case let .foundTransactions(transactions, range):
-                    self?.foundTransactions(transactions: transactions, in: range)
+            case let .handledReorg(reorgHeight, rewindHeight):
+                self?.handledReorg(reorgHeight: reorgHeight, rewindHeight: rewindHeight)
 
-                case let .handledReorg(reorgHeight, rewindHeight):
-                    self?.handledReorg(reorgHeight: reorgHeight, rewindHeight: rewindHeight)
+            case let .progressUpdated(progress):
+                await self?.progressUpdated(progress: progress)
 
-                case let .progressUpdated(progress):
-                    self?.progressUpdated(progress: progress)
+            case let .storedUTXOs(utxos):
+                self?.storedUTXOs(utxos: utxos)
 
-                case let .storedUTXOs(utxos):
-                    self?.storedUTXOs(utxos: utxos)
+            case .startedEnhancing:
+                await self?.updateStatus(.enhancing(.zero))
 
-                case .startedEnhancing:
-                    self?.status = .enhancing(.zero)
+            case .startedFetching:
+                await self?.updateStatus(.fetching)
 
-                case .startedFetching:
-                    self?.status = .fetching
+            case .startedSyncing:
+                await self?.updateStatus(.syncing(.nullProgress))
 
-                case .startedSyncing:
-                    self?.status = .syncing(.nullProgress)
-
-                case .stopped:
-                    self?.status = .stopped
-                }
+            case .stopped:
+                await self?.updateStatus(.stopped)
             }
-            .store(in: &longLivingCancelables)
+        }
+
+        await processor.updateEventClosure(identifier: "SDKSynchronizer", closure: eventClosure)
     }
 
-    private func failed(error: CompactBlockProcessorError) {
-        status = .error(self.mapError(error))
+    private func failed(error: CompactBlockProcessorError) async {
+        await updateStatus(.error(self.mapError(error)))
     }
 
-    private func finished(lastScannedHeight: BlockHeight, foundBlocks: Bool) {
+    private func finished(lastScannedHeight: BlockHeight, foundBlocks: Bool) async {
         // FIX: Pending transaction updates fail if done from another thread. Improvement needed: explicitly define queues for sql repositories see: https://github.com/zcash/ZcashLightClientKit/issues/450
         self.latestScannedHeight = lastScannedHeight
         self.refreshPendingTransactions()
-        self.status = .synced
+        await updateStatus(.synced)
 
         if let syncStartDate {
             SDKMetrics.shared.pushSyncReport(
@@ -271,15 +255,9 @@ public class SDKSynchronizer: Synchronizer {
         }
     }
 
-    private func progressUpdated(progress: CompactBlockProgress) {
-        switch progress {
-        case let .syncing(progress):
-            status = .syncing(progress)
-        case let .enhance(progress):
-            status = .enhancing(progress)
-        case .fetch:
-            status = .fetching
-        }
+    private func progressUpdated(progress: CompactBlockProgress) async {
+        let newStatus = SyncStatus(progress)
+        await updateStatus(newStatus)
     }
 
     private func storedUTXOs(utxos: (inserted: [UnspentTransactionOutputEntity], skipped: [UnspentTransactionOutputEntity])) {
@@ -427,17 +405,6 @@ public class SDKSynchronizer: Synchronizer {
         return transactionRepository.getRecipients(for: transaction.id)
     }
 
-    public func latestHeight(result: @escaping (Result<BlockHeight, Error>) -> Void) {
-        Task {
-            do {
-                let latestBlockHeight = try await blockProcessor.blockDownloaderService.latestBlockHeightAsync()
-                result(.success(latestBlockHeight))
-            } catch {
-                result(.failure(error))
-            }
-        }
-    }
-
     public func latestHeight() async throws -> BlockHeight {
         try await blockProcessor.blockDownloaderService.latestBlockHeightAsync()
     }
@@ -561,7 +528,7 @@ public class SDKSynchronizer: Synchronizer {
                     self?.transactionRepository.closeDBConnection()
                 },
                 completion: { [weak self] possibleError in
-                    self?.status = .unprepared
+                    await self?.updateStatus(.unprepared)
                     if let error = possibleError {
                         subject.send(completion: .failure(error))
                     } else {
@@ -590,33 +557,31 @@ public class SDKSynchronizer: Synchronizer {
         )
     }
 
-    private func notify(oldStatus: SyncStatus, newStatus: SyncStatus) {
+    private func notify(oldStatus: SyncStatus, newStatus: SyncStatus) async {
         guard oldStatus != newStatus else { return }
+
+        let newState: SynchronizerState
 
         // When the wipe happens status is switched to `unprepared`. And we expect that everything is deleted. All the databases including data DB.
         // When new snapshot is created balance is checked. And when balance is checked and data DB doesn't exist then rust initialise new database.
         // So it's necessary to not create new snapshot after status is switched to `unprepared` otherwise data DB exists after wipe
         if newStatus == .unprepared {
-            latestState = SynchronizerState.zero
-            updateStateStream(with: latestState)
+            newState = SynchronizerState.zero
         } else {
-            let didStatusChange = areTwoStatusesDifferent(firstStatus: oldStatus, secondStatus: newStatus)
-
-            if didStatusChange {
-                Task {
-                    latestState = await snapshotState(status: newStatus)
-                    updateStateStream(with: latestState)
-                }
+            if areTwoStatusesDifferent(firstStatus: oldStatus, secondStatus: newStatus) {
+                newState = await snapshotState(status: newStatus)
             } else {
-                latestState = SynchronizerState(
+                newState = SynchronizerState(
                     shieldedBalance: latestState.shieldedBalance,
                     transparentBalance: latestState.transparentBalance,
                     syncStatus: newStatus,
                     latestScannedHeight: latestState.latestScannedHeight
                 )
-                updateStateStream(with: latestState)
             }
         }
+
+        latestState = newState
+        updateStateStream(with: latestState)
     }
 
     private func areTwoStatusesDifferent(firstStatus: SyncStatus, secondStatus: SyncStatus) -> Bool {

--- a/Sources/ZcashLightClientKit/Utils/GenericActor.swift
+++ b/Sources/ZcashLightClientKit/Utils/GenericActor.swift
@@ -1,0 +1,18 @@
+//
+//  GenericActor.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Foundation
+
+actor GenericActor<T> {
+    var value: T
+    init(_ value: T) { self.value = value }
+    func update(_ newValue: T) async -> T {
+        let oldValue = value
+        value = newValue
+        return oldValue
+    }
+}

--- a/Sources/ZcashLightClientKit/Utils/SaplingParameterDownloader.swift
+++ b/Sources/ZcashLightClientKit/Utils/SaplingParameterDownloader.swift
@@ -132,7 +132,7 @@ private extension SaplingParameterDownloader {
         at destination: URL,
         result: @escaping (Result<URL, Error>) -> Void
     ) {
-        LoggerProxy.debug("Downloading sapling file from \(request.url)")
+        LoggerProxy.debug("Downloading sapling file from \(String(describing: request.url))")
         let task = URLSession.shared.downloadTask(with: request) { url, _, error in
             if let error {
                 result(.failure(Errors.failed(error: error)))

--- a/Tests/DarksideTests/DarksideSanityCheckTests.swift
+++ b/Tests/DarksideTests/DarksideSanityCheckTests.swift
@@ -26,7 +26,7 @@ class DarksideSanityCheckTests: XCTestCase {
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        self.coordinator = try TestCoordinator(
+        self.coordinator = TestCoordinator.make(
             walletBirthday: self.birthday,
             network: self.network
         )
@@ -37,14 +37,14 @@ class DarksideSanityCheckTests: XCTestCase {
     
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try coordinator.stop()
+        wait { try await self.coordinator.stop() }
         try? FileManager.default.removeItem(at: coordinator.databases.fsCacheDbRoot)
         try? FileManager.default.removeItem(at: coordinator.databases.dataDB)
         try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
         coordinator = nil
     }
     
-    func testDarkside() throws {
+    func testDarkside() async throws {
         let expectedFirstBlock = (height: BlockHeight(663150), hash: "0000000002fd3be4c24c437bd22620901617125ec2a3a6c902ec9a6c06f734fc")
         let expectedLastBlock = (height: BlockHeight(663200), hash: "2fc7b4682f5ba6ba6f86e170b40f0aa9302e1d3becb2a6ee0db611ff87835e4a")
         
@@ -54,7 +54,7 @@ class DarksideSanityCheckTests: XCTestCase {
         
         let syncExpectation = XCTestExpectation(description: "sync to \(expectedLastBlock.height)")
         
-        try coordinator.sync(
+        try await coordinator.sync(
             completion: { _ in
                 syncExpectation.fulfill()
             },

--- a/Tests/DarksideTests/ReOrgTests.swift
+++ b/Tests/DarksideTests/ReOrgTests.swift
@@ -44,30 +44,25 @@ class ReOrgTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.coordinator = try TestCoordinator(
-            walletBirthday: self.birthday,
-            network: self.network
-        )
+        self.coordinator = TestCoordinator.make(walletBirthday: self.birthday, network: self.network)
 
         try self.coordinator.reset(saplingActivation: self.birthday, branchID: self.branchID, chainName: self.chainName)
 
         try self.coordinator.resetBlocks(dataset: .default)
 
-        var stream: AnyPublisher<CompactBlockProcessor.Event, Never>!
-        XCTestCase.wait { await stream = self.coordinator.synchronizer.blockProcessor.eventStream }
-        stream
-            .sink { [weak self] event in
-                switch event {
-                case .handledReorg: self?.handleReOrgNotification(event: event)
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .handledReorg: self?.handleReOrgNotification(event: event)
+            default: break
             }
-            .store(in: &cancellables)
+        }
+
+        XCTestCase.wait { await self.coordinator.synchronizer.blockProcessor.updateEventClosure(identifier: "tests", closure: eventClosure) }
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try coordinator.stop()
+        wait { try await self.coordinator.stop() }
         try? FileManager.default.removeItem(at: coordinator.databases.fsCacheDbRoot)
         try? FileManager.default.removeItem(at: coordinator.databases.dataDB)
         try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
@@ -87,13 +82,13 @@ class ReOrgTests: XCTestCase {
         XCTAssertNoThrow(rewindHeight > 0)
     }
     
-    func testBasicReOrg() throws {
+    func testBasicReOrg() async throws {
         let mockLatestHeight = BlockHeight(663200)
         let targetLatestHeight = BlockHeight(663202)
         let reOrgHeight = BlockHeight(663195)
         let walletBirthday = Checkpoint.birthday(with: 663150, network: network).height
         
-        try basicReOrgTest(
+        try await basicReOrgTest(
             baseDataset: .beforeReOrg,
             reorgDataset: .afterSmallReorg,
             firstLatestHeight: mockLatestHeight,
@@ -103,13 +98,13 @@ class ReOrgTests: XCTestCase {
         )
     }
     
-    func testTenPlusBlockReOrg() throws {
+    func testTenPlusBlockReOrg() async throws {
         let mockLatestHeight = BlockHeight(663200)
         let targetLatestHeight = BlockHeight(663250)
         let reOrgHeight = BlockHeight(663180)
         let walletBirthday = Checkpoint.birthday(with: BlockHeight(663150), network: network).height
         
-        try basicReOrgTest(
+        try await basicReOrgTest(
             baseDataset: .beforeReOrg,
             reorgDataset: .afterLargeReorg,
             firstLatestHeight: mockLatestHeight,
@@ -126,7 +121,7 @@ class ReOrgTests: XCTestCase {
         reorgHeight: BlockHeight,
         walletBirthday: BlockHeight,
         targetHeight: BlockHeight
-    ) throws {
+    ) async throws {
         do {
             try coordinator.reset(saplingActivation: birthday, branchID: branchID, chainName: chainName)
             try coordinator.resetBlocks(dataset: .predefined(dataset: .beforeReOrg))
@@ -143,7 +138,7 @@ class ReOrgTests: XCTestCase {
         download and sync blocks from walletBirthday to firstLatestHeight
         */
         var synchronizer: SDKSynchronizer?
-        try coordinator.sync(
+        try await coordinator.sync(
             completion: { synchro in
                 synchronizer = synchro
                 firstSyncExpectation.fulfill()
@@ -180,7 +175,7 @@ class ReOrgTests: XCTestCase {
         let secondSyncExpectation = XCTestExpectation(description: "second sync")
         
         sleep(2)
-        try coordinator.sync(
+        try await coordinator.sync(
             completion: { _ in
                 secondSyncExpectation.fulfill()
             },

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -131,16 +131,14 @@ class TransactionEnhancementTests: XCTestCase {
             config: processorConfig
         )
 
-        var stream: AnyPublisher<CompactBlockProcessor.Event, Never>!
-        XCTestCase.wait { await stream = self.processor.eventStream }
-        stream
-            .sink { [weak self] event in
-                switch event {
-                case .failed: self?.processorFailed(event: event)
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .failed: self?.processorFailed(event: event)
+            default: break
             }
-            .store(in: &cancellables)
+        }
+
+        XCTestCase.wait { await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure) }
     }
     
     override func tearDownWithError() throws {
@@ -167,8 +165,8 @@ class TransactionEnhancementTests: XCTestCase {
             .foundTransactions: txFoundNotificationExpectation,
             .finished: finishedNotificationExpectation
         ]
-        processorEventHandler.subscribe(to: await processor.eventStream, expectations: expectations)
 
+        await processorEventHandler.subscribe(to: processor, expectations: expectations)
         await processor.start()
     }
     

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -197,14 +197,14 @@ class BlockScanTests: XCTestCase {
             config: processorConfig
         )
 
-        await compactBlockProcessor.eventStream
-            .sink { [weak self] event in
-                switch event {
-                case .progressUpdated: self?.observeBenchmark()
-                default: break
-                }
+        let eventClosure: CompactBlockProcessor.EventClosure = { [weak self] event in
+            switch event {
+            case .progressUpdated: self?.observeBenchmark()
+            default: break
             }
-            .store(in: &cancelables)
+        }
+
+        await compactBlockProcessor.updateEventClosure(identifier: "tests", closure: eventClosure)
 
         let range = CompactBlockRange(
             uncheckedBounds: (walletBirthDay.height, walletBirthDay.height + 10000)

--- a/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
@@ -1,0 +1,774 @@
+//
+//  ClosureSynchronizerOfflineTests.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Combine
+import Foundation
+@testable import TestUtils
+import XCTest
+@testable import ZcashLightClientKit
+
+extension String: Error { }
+
+class ClosureSynchronizerOfflineTests: XCTestCase {
+    var data: AlternativeSynchronizerAPITestsData!
+
+    var cancellables: [AnyCancellable] = []
+    var synchronizerMock: SynchronizerMock!
+    var synchronizer: ClosureSDKSynchronizer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        data = AlternativeSynchronizerAPITestsData()
+        synchronizerMock = SynchronizerMock()
+        synchronizer = ClosureSDKSynchronizer(synchronizer: synchronizerMock)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        data = nil
+    }
+
+    func testStateStreamEmitsAsExpected() {
+        let state = SynchronizerState(
+            shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
+            transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
+            syncStatus: .fetching,
+            latestScannedHeight: 111111
+        )
+        synchronizerMock.underlyingStateStream = Just(state).eraseToAnyPublisher()
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.stateStream
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { receivedState in
+                    XCTAssertEqual(receivedState, state)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testLatestStateIsAsExpected() {
+        let state = SynchronizerState(
+            shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
+            transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
+            syncStatus: .fetching,
+            latestScannedHeight: 111111
+        )
+        synchronizerMock.underlyingLatestState = state
+
+        XCTAssertEqual(synchronizer.latestState, state)
+    }
+
+    func testEventStreamEmitsAsExpected() {
+        synchronizerMock.underlyingEventStream = Just(.connectionStateChanged).eraseToAnyPublisher()
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.eventStream
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { event in
+                    if case .connectionStateChanged = event {
+                    } else {
+                        XCTFail("Unexpected event: \(event)")
+                    }
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testConnectionStateAsExpected() {
+        synchronizerMock.underlyingConnectionState = .reconnecting
+        XCTAssertEqual(synchronizer.connectionState, .reconnecting)
+    }
+
+    func testPrepareSucceed() throws {
+        synchronizerMock.prepareWithSeedViewingKeysWalletBirthdayClosure = { receivedSeed, receivedViewingKeys, receivedWalletBirthday in
+            XCTAssertEqual(receivedSeed, self.data.seed)
+            XCTAssertEqual(receivedViewingKeys, [self.data.viewingKey])
+            XCTAssertEqual(receivedWalletBirthday, self.data.birthday)
+            return .success
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.prepare(with: data.seed, viewingKeys: [data.viewingKey], walletBirthday: data.birthday) { result in
+            switch result {
+            case let .success(status):
+                XCTAssertEqual(status, .success)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testPrepareThrowsError() throws {
+        synchronizerMock.prepareWithSeedViewingKeysWalletBirthdayClosure = { _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.prepare(with: data.seed, viewingKeys: [data.viewingKey], walletBirthday: data.birthday) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+                expectation.fulfill()
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStartSucceeds() {
+        synchronizerMock.startRetryClosure = { retry in
+            XCTAssertTrue(retry)
+            return
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.start(retry: true) { error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStartThrowsError() {
+        synchronizerMock.startRetryClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.start(retry: true) { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStopSucceed() {
+        var stopCalled = false
+        synchronizerMock.stopClosure = {
+            stopCalled = true
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.stop() {
+            XCTAssertTrue(stopCalled)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetSaplingAddressSucceed() {
+        synchronizerMock.getSaplingAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.saplingAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getSaplingAddress(accountIndex: 3) { receivedAddress in
+            XCTAssertEqual(receivedAddress, self.data.saplingAddress)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetUnifiedAddressSucceed() {
+        synchronizerMock.getUnifiedAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.unifiedAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getUnifiedAddress(accountIndex: 3) { receivedAddress in
+            XCTAssertEqual(receivedAddress, self.data.unifiedAddress)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentAddressSucceed() {
+        synchronizerMock.getTransparentAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.transparentAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentAddress(accountIndex: 3) { receivedAddress in
+            XCTAssertEqual(receivedAddress, self.data.transparentAddress)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testSendToAddressSucceed() throws {
+        let amount = Zatoshi(100)
+        let recipient: Recipient = .transparent(data.transparentAddress)
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock
+            .sendToAddressSpendingKeyZatoshiToAddressMemoClosure = { receivedSpendingKey, receivedZatoshi, receivedToAddress, receivedMemo in
+                XCTAssertEqual(receivedSpendingKey, self.data.spendingKey)
+                XCTAssertEqual(receivedZatoshi, amount)
+                XCTAssertEqual(receivedToAddress, recipient)
+                XCTAssertEqual(receivedMemo, memo)
+                return self.data.pendingTransactionEntity
+            }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.sendToAddress(spendingKey: data.spendingKey, zatoshi: amount, toAddress: recipient, memo: memo) { result in
+            switch result {
+            case let .success(receivedEntity):
+                XCTAssertEqual(receivedEntity.recipient, self.data.pendingTransactionEntity.recipient)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testSendToAddressThrowsError() throws {
+        let amount = Zatoshi(100)
+        let recipient: Recipient = .transparent(data.transparentAddress)
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.sendToAddressSpendingKeyZatoshiToAddressMemoClosure = { _, _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.sendToAddress(spendingKey: data.spendingKey, zatoshi: amount, toAddress: recipient, memo: memo) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testShieldFundsSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+        let shieldingThreshold = Zatoshi(1)
+
+        synchronizerMock.shieldFundsSpendingKeyMemoShieldingThresholdClosure = { receivedSpendingKey, receivedMemo, receivedShieldingThreshold in
+            XCTAssertEqual(receivedSpendingKey, self.data.spendingKey)
+            XCTAssertEqual(receivedMemo, memo)
+            XCTAssertEqual(receivedShieldingThreshold, shieldingThreshold)
+            return self.data.pendingTransactionEntity
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.shieldFunds(spendingKey: data.spendingKey, memo: memo, shieldingThreshold: shieldingThreshold) { result in
+            switch result {
+            case let .success(receivedEntity):
+                XCTAssertEqual(receivedEntity.recipient, self.data.pendingTransactionEntity.recipient)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testShieldFundsThrowsError() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+        let shieldingThreshold = Zatoshi(1)
+
+        synchronizerMock.shieldFundsSpendingKeyMemoShieldingThresholdClosure = { _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.shieldFunds(spendingKey: data.spendingKey, memo: memo, shieldingThreshold: shieldingThreshold) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testCancelSpendSucceed() {
+        synchronizerMock.cancelSpendTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.recipient, self.data.pendingTransactionEntity.recipient)
+            return true
+        }
+
+        let result = synchronizer.cancelSpend(transaction: data.pendingTransactionEntity)
+        XCTAssertTrue(result)
+    }
+
+    func testPendingTransactionsSucceed() {
+        synchronizerMock.underlyingPendingTransactions = [data.pendingTransactionEntity]
+        let transactions = synchronizer.pendingTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].recipient, self.data.pendingTransactionEntity.recipient)
+    }
+
+    func testClearedTransactionsSucceed() {
+        synchronizerMock.underlyingClearedTransactions = [data.clearedTransaction]
+        let transactions = synchronizer.clearedTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+    }
+
+    func testSentTransactionsSucceed() {
+        synchronizerMock.underlyingSentTransactions = [data.sentTransaction]
+        let transactions = synchronizer.sentTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.sentTransaction.id)
+    }
+
+    func testReceivedTransactionsSucceed() {
+        synchronizerMock.underlyingReceivedTransactions = [data.receivedTransaction]
+        let transactions = synchronizer.receivedTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.receivedTransaction.id)
+    }
+
+    func testGetMemosForClearedTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.clearedTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForClearedTransactionThrowsError() {
+        synchronizerMock.getMemosForTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.clearedTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetMemosForReceivedTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForReceivedTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.receivedTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.receivedTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForReceivedTransactionThrowsError() {
+        synchronizerMock.getMemosForReceivedTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.receivedTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetMemosForSentTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForSentTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.sentTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.sentTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForSentTransactionThrowsError() {
+        synchronizerMock.getMemosForSentTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.sentTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetRecipientsForClearedTransaction() {
+        let expectedRecipient: TransactionRecipient = .address(.transparent(data.transparentAddress))
+
+        synchronizerMock.getRecipientsForClearedTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            return [expectedRecipient]
+        }
+
+        let recipients = synchronizer.getRecipients(for: data.clearedTransaction)
+
+        XCTAssertEqual(recipients.count, 1)
+        XCTAssertEqual(recipients[0], expectedRecipient)
+    }
+
+    func testGetRecipientsForSentTransaction() {
+        let expectedRecipient: TransactionRecipient = .address(.transparent(data.transparentAddress))
+
+        synchronizerMock.getRecipientsForSentTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.sentTransaction.id)
+            return [expectedRecipient]
+        }
+
+        let recipients = synchronizer.getRecipients(for: data.sentTransaction)
+
+        XCTAssertEqual(recipients.count, 1)
+        XCTAssertEqual(recipients[0], expectedRecipient)
+    }
+
+    func testAllConfirmedTransactionsSucceed() throws {
+        synchronizerMock.allConfirmedTransactionsFromTransactionClosure = { receivedTransaction, limit in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            XCTAssertEqual(limit, 3)
+            return [self.data.clearedTransaction]
+        }
+
+        let transactions = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
+
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+    }
+
+    func testAllConfirmedTransactionsThrowsError() throws {
+        synchronizerMock.allConfirmedTransactionsFromTransactionClosure = { _, _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testLatestHeightSucceed() {
+        synchronizerMock.latestHeightClosure = { 123000 }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.latestHeight() { result in
+            switch result {
+            case let .success(receivedHeight):
+                XCTAssertEqual(receivedHeight, 123000)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testLatestHeightThrowsError() {
+        synchronizerMock.latestHeightClosure = {
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.latestHeight() { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRefreshUTXOsSucceed() {
+        let insertedEntity = UnspentTransactionOutputEntityMock(address: "addr", txid: Data(), index: 0, script: Data(), valueZat: 1, height: 2)
+        let skippedEntity = UnspentTransactionOutputEntityMock(address: "addr2", txid: Data(), index: 1, script: Data(), valueZat: 2, height: 3)
+        let refreshedUTXO = (inserted: [insertedEntity], skipped: [skippedEntity])
+
+        synchronizerMock.refreshUTXOsAddressFromHeightClosure = { receivedAddress, receivedFromHeight in
+            XCTAssertEqual(receivedAddress, self.data.transparentAddress)
+            XCTAssertEqual(receivedFromHeight, 121000)
+            return refreshedUTXO
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.refreshUTXOs(address: data.transparentAddress, from: 121000) { result in
+            switch result {
+            case let .success(utxos):
+                XCTAssertEqual(utxos.inserted as! [UnspentTransactionOutputEntityMock], [insertedEntity])
+                XCTAssertEqual(utxos.skipped as! [UnspentTransactionOutputEntityMock], [skippedEntity])
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRefreshUTXOsThrowsError() {
+        synchronizerMock.refreshUTXOsAddressFromHeightClosure = { _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.refreshUTXOs(address: data.transparentAddress, from: 121000) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentBalanceSucceed() {
+        let expectedWalletBalance = WalletBalance(verified: Zatoshi(100), total: Zatoshi(200))
+
+        synchronizerMock.getTransparentBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return expectedWalletBalance
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentBalance(accountIndex: 3) { result in
+            switch result {
+            case let .success(receivedBalance):
+                XCTAssertEqual(receivedBalance, expectedWalletBalance)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentBalanceThrowsError() {
+        synchronizerMock.getTransparentBalanceAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentBalance(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedBalanceDeprecatedSucceed() {
+        synchronizerMock.getShieldedBalanceAccountIndexDeprecatedClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return 333
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), 333)
+    }
+
+    func testGetShieldedBalanceSucceed() {
+        synchronizerMock.getShieldedBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return Zatoshi(333)
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), Zatoshi(333))
+    }
+
+    func testGetShieldedVerifiedBalanceDeprecatedSucceed() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexDeprecatedClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return 333
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), 333)
+    }
+
+    func testGetShieldedVerifiedBalanceSucceed() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return Zatoshi(333)
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), Zatoshi(333))
+    }
+
+    func testRewindSucceed() {
+        synchronizerMock.rewindPolicyClosure = { receivedPolicy in
+            if case .quick = receivedPolicy {
+            } else {
+                XCTFail("Unexpected policy \(receivedPolicy)")
+            }
+
+            return Empty().eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.rewind(.quick)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure \(error)")
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRewindThrowsError() {
+        synchronizerMock.rewindPolicyClosure = { _ in
+            return Fail(error: "some error").eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.rewind(.quick)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Failure is expected")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testWipeSucceed() {
+        synchronizerMock.wipeClosure = {
+            return Empty().eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.wipe()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure \(error)")
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testWipeThrowsError() {
+        synchronizerMock.wipeClosure = {
+            return Fail(error: "some error").eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.wipe()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Failure is expected")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+}

--- a/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
@@ -1,0 +1,916 @@
+//
+//  CombineSynchronizerOfflineTests.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Combine
+import Foundation
+@testable import TestUtils
+import XCTest
+@testable import ZcashLightClientKit
+
+class CombineSynchronizerOfflineTests: XCTestCase {
+    var data: AlternativeSynchronizerAPITestsData!
+
+    var cancellables: [AnyCancellable] = []
+    var synchronizerMock: SynchronizerMock!
+    var synchronizer: CombineSDKSynchronizer!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        data = AlternativeSynchronizerAPITestsData()
+        synchronizerMock = SynchronizerMock()
+        synchronizer = CombineSDKSynchronizer(synchronizer: synchronizerMock)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        data = nil
+    }
+
+    func testStateStreamEmitsAsExpected() {
+        let state = SynchronizerState(
+            shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
+            transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
+            syncStatus: .fetching,
+            latestScannedHeight: 111111
+        )
+        synchronizerMock.underlyingStateStream = Just(state).eraseToAnyPublisher()
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.stateStream
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { receivedState in
+                    XCTAssertEqual(receivedState, state)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testLatestStateIsAsExpected() {
+        let state = SynchronizerState(
+            shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
+            transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
+            syncStatus: .fetching,
+            latestScannedHeight: 111111
+        )
+        synchronizerMock.underlyingLatestState = state
+
+        XCTAssertEqual(synchronizer.latestState, state)
+    }
+
+    func testEventStreamEmitsAsExpected() {
+        synchronizerMock.underlyingEventStream = Just(.connectionStateChanged).eraseToAnyPublisher()
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.eventStream
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { event in
+                    if case .connectionStateChanged = event {
+                    } else {
+                        XCTFail("Unexpected event: \(event)")
+                    }
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testConnectionStateAsExpected() {
+        synchronizerMock.underlyingConnectionState = .reconnecting
+        XCTAssertEqual(synchronizer.connectionState, .reconnecting)
+    }
+
+    func testPrepareSucceed() throws {
+        synchronizerMock.prepareWithSeedViewingKeysWalletBirthdayClosure = { receivedSeed, receivedViewingKeys, receivedWalletBirthday in
+            XCTAssertEqual(receivedSeed, self.data.seed)
+            XCTAssertEqual(receivedViewingKeys, [self.data.viewingKey])
+            XCTAssertEqual(receivedWalletBirthday, self.data.birthday)
+            return .success
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.prepare(with: data.seed, viewingKeys: [data.viewingKey], walletBirthday: data.birthday)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, .success)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testPrepareThrowsError() throws {
+        synchronizerMock.prepareWithSeedViewingKeysWalletBirthdayClosure = { _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.prepare(with: data.seed, viewingKeys: [data.viewingKey], walletBirthday: data.birthday)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStartSucceeds() {
+        synchronizerMock.startRetryClosure = { retry in
+            XCTAssertTrue(retry)
+            return
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.start(retry: true)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStartThrowsError() {
+        synchronizerMock.startRetryClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.start(retry: true)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testStopSucceed() {
+        var stopCalled = false
+        synchronizerMock.stopClosure = {
+            stopCalled = true
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.stop()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTAssertTrue(stopCalled)
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetSaplingAddressSucceed() {
+        synchronizerMock.getSaplingAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.saplingAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getSaplingAddress(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, self.data.saplingAddress)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetUnifiedAddressSucceed() {
+        synchronizerMock.getUnifiedAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.unifiedAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getUnifiedAddress(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, self.data.unifiedAddress)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentAddressSucceed() {
+        synchronizerMock.getTransparentAddressAccountIndexClosure = { accountIndex in
+            XCTAssertEqual(accountIndex, 3)
+            return self.data.transparentAddress
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentAddress(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, self.data.transparentAddress)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testSendToAddressSucceed() throws {
+        let amount = Zatoshi(100)
+        let recipient: Recipient = .transparent(data.transparentAddress)
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock
+            .sendToAddressSpendingKeyZatoshiToAddressMemoClosure = { receivedSpendingKey, receivedZatoshi, receivedToAddress, receivedMemo in
+                XCTAssertEqual(receivedSpendingKey, self.data.spendingKey)
+                XCTAssertEqual(receivedZatoshi, amount)
+                XCTAssertEqual(receivedToAddress, recipient)
+                XCTAssertEqual(receivedMemo, memo)
+                return self.data.pendingTransactionEntity
+            }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.sendToAddress(spendingKey: data.spendingKey, zatoshi: amount, toAddress: recipient, memo: memo)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value.recipient, self.data.pendingTransactionEntity.recipient)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testSendToAddressThrowsError() throws {
+        let amount = Zatoshi(100)
+        let recipient: Recipient = .transparent(data.transparentAddress)
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.sendToAddressSpendingKeyZatoshiToAddressMemoClosure = { _, _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.sendToAddress(spendingKey: data.spendingKey, zatoshi: amount, toAddress: recipient, memo: memo)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testShieldFundsSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+        let shieldingThreshold = Zatoshi(1)
+
+        synchronizerMock.shieldFundsSpendingKeyMemoShieldingThresholdClosure = { receivedSpendingKey, receivedMemo, receivedShieldingThreshold in
+            XCTAssertEqual(receivedSpendingKey, self.data.spendingKey)
+            XCTAssertEqual(receivedMemo, memo)
+            XCTAssertEqual(receivedShieldingThreshold, shieldingThreshold)
+            return self.data.pendingTransactionEntity
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.shieldFunds(spendingKey: data.spendingKey, memo: memo, shieldingThreshold: shieldingThreshold)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value.recipient, self.data.pendingTransactionEntity.recipient)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testShieldFundsThrowsError() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+        let shieldingThreshold = Zatoshi(1)
+
+        synchronizerMock.shieldFundsSpendingKeyMemoShieldingThresholdClosure = { _, _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.shieldFunds(spendingKey: data.spendingKey, memo: memo, shieldingThreshold: shieldingThreshold)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testCancelSpendSucceed() {
+        synchronizerMock.cancelSpendTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.recipient, self.data.pendingTransactionEntity.recipient)
+            return true
+        }
+
+        let result = synchronizer.cancelSpend(transaction: data.pendingTransactionEntity)
+        XCTAssertTrue(result)
+    }
+
+    func testPendingTransactionsSucceed() {
+        synchronizerMock.underlyingPendingTransactions = [data.pendingTransactionEntity]
+        let transactions = synchronizer.pendingTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].recipient, self.data.pendingTransactionEntity.recipient)
+    }
+
+    func testClearedTransactionsSucceed() {
+        synchronizerMock.underlyingClearedTransactions = [data.clearedTransaction]
+        let transactions = synchronizer.clearedTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+    }
+
+    func testSentTransactionsSucceed() {
+        synchronizerMock.underlyingSentTransactions = [data.sentTransaction]
+        let transactions = synchronizer.sentTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.sentTransaction.id)
+    }
+
+    func testReceivedTransactionsSucceed() {
+        synchronizerMock.underlyingReceivedTransactions = [data.receivedTransaction]
+        let transactions = synchronizer.receivedTransactions
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.receivedTransaction.id)
+    }
+
+    func testGetMemosForClearedTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.clearedTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForClearedTransactionThrowsError() {
+        synchronizerMock.getMemosForTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.clearedTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetMemosForReceivedTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForReceivedTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.receivedTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.receivedTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForReceivedTransactionThrowsError() {
+        synchronizerMock.getMemosForReceivedTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.receivedTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetMemosForSentTransactionSucceed() throws {
+        let memo: Memo = .text(try MemoText("Some message"))
+
+        synchronizerMock.getMemosForSentTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.sentTransaction.id)
+            return [memo]
+        }
+
+        let memos = try synchronizer.getMemos(for: data.sentTransaction)
+
+        XCTAssertEqual(memos.count, 1)
+        XCTAssertEqual(memos[0], memo)
+    }
+
+    func testGetMemosForSentTransactionThrowsError() {
+        synchronizerMock.getMemosForSentTransactionClosure = { _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.getMemos(for: data.sentTransaction)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testGetRecipientsForClearedTransaction() {
+        let expectedRecipient: TransactionRecipient = .address(.transparent(data.transparentAddress))
+
+        synchronizerMock.getRecipientsForClearedTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            return [expectedRecipient]
+        }
+
+        let recipients = synchronizer.getRecipients(for: data.clearedTransaction)
+
+        XCTAssertEqual(recipients.count, 1)
+        XCTAssertEqual(recipients[0], expectedRecipient)
+    }
+
+    func testGetRecipientsForSentTransaction() {
+        let expectedRecipient: TransactionRecipient = .address(.transparent(data.transparentAddress))
+
+        synchronizerMock.getRecipientsForSentTransactionClosure = { receivedTransaction in
+            XCTAssertEqual(receivedTransaction.id, self.data.sentTransaction.id)
+            return [expectedRecipient]
+        }
+
+        let recipients = synchronizer.getRecipients(for: data.sentTransaction)
+
+        XCTAssertEqual(recipients.count, 1)
+        XCTAssertEqual(recipients[0], expectedRecipient)
+    }
+
+    func testAllConfirmedTransactionsSucceed() throws {
+        synchronizerMock.allConfirmedTransactionsFromTransactionClosure = { receivedTransaction, limit in
+            XCTAssertEqual(receivedTransaction.id, self.data.clearedTransaction.id)
+            XCTAssertEqual(limit, 3)
+            return [self.data.clearedTransaction]
+        }
+
+        let transactions = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
+
+        XCTAssertEqual(transactions.count, 1)
+        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+    }
+
+    func testAllConfirmedTransactionsThrowsError() throws {
+        synchronizerMock.allConfirmedTransactionsFromTransactionClosure = { _, _ in
+            throw "Some error"
+        }
+
+        do {
+            _ = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
+            XCTFail("Failure is expected")
+        } catch { }
+    }
+
+    func testLatestHeightSucceed() {
+        synchronizerMock.latestHeightClosure = { 123000 }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.latestHeight()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, 123000)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testLatestHeightThrowsError() {
+        synchronizerMock.latestHeightClosure = {
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.latestHeight()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRefreshUTXOsSucceed() {
+        let insertedEntity = UnspentTransactionOutputEntityMock(address: "addr", txid: Data(), index: 0, script: Data(), valueZat: 1, height: 2)
+        let skippedEntity = UnspentTransactionOutputEntityMock(address: "addr2", txid: Data(), index: 1, script: Data(), valueZat: 2, height: 3)
+        let refreshedUTXO = (inserted: [insertedEntity], skipped: [skippedEntity])
+
+        synchronizerMock.refreshUTXOsAddressFromHeightClosure = { receivedAddress, receivedFromHeight in
+            XCTAssertEqual(receivedAddress, self.data.transparentAddress)
+            XCTAssertEqual(receivedFromHeight, 121000)
+            return refreshedUTXO
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.refreshUTXOs(address: data.transparentAddress, from: 121000)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value.inserted as! [UnspentTransactionOutputEntityMock], [insertedEntity])
+                    XCTAssertEqual(value.skipped as! [UnspentTransactionOutputEntityMock], [skippedEntity])
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRefreshUTXOsThrowsError() {
+        synchronizerMock.refreshUTXOsAddressFromHeightClosure = { _, _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.refreshUTXOs(address: data.transparentAddress, from: 121000)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentBalanceSucceed() {
+        let expectedWalletBalance = WalletBalance(verified: Zatoshi(100), total: Zatoshi(200))
+
+        synchronizerMock.getTransparentBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return expectedWalletBalance
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, expectedWalletBalance)
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentBalanceThrowsError() {
+        synchronizerMock.getTransparentBalanceAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedBalanceDeprecatedSucceed() {
+        synchronizerMock.getShieldedBalanceAccountIndexDeprecatedClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return 333
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), 333)
+    }
+
+    func testGetShieldedBalanceSucceed() {
+        synchronizerMock.getShieldedBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return Zatoshi(333)
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), Zatoshi(333))
+    }
+
+    func testGetShieldedVerifiedBalanceDeprecatedSucceed() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexDeprecatedClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return 333
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), 333)
+    }
+
+    func testGetShieldedVerifiedBalanceSucceed() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexClosure = { receivedAccountIndex in
+            XCTAssertEqual(receivedAccountIndex, 3)
+            return Zatoshi(333)
+        }
+
+        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), Zatoshi(333))
+    }
+
+    func testRewindSucceed() {
+        synchronizerMock.rewindPolicyClosure = { receivedPolicy in
+            if case .quick = receivedPolicy {
+            } else {
+                XCTFail("Unexpected policy \(receivedPolicy)")
+            }
+
+            return Empty().eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.rewind(.quick)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure \(error)")
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testRewindThrowsError() {
+        synchronizerMock.rewindPolicyClosure = { _ in
+            return Fail(error: "some error").eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.rewind(.quick)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Failure is expected")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testWipeSucceed() {
+        synchronizerMock.wipeClosure = {
+            return Empty().eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.wipe()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unexpected failure \(error)")
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testWipeThrowsError() {
+        synchronizerMock.wipeClosure = {
+            return Fail(error: "some error").eraseToAnyPublisher()
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.wipe()
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Failure is expected")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+}

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -39,7 +39,7 @@ class WalletTests: XCTestCase {
         try? self.testFileManager.removeItem(at: self.testTempDirectory)
     }
     
-    func testWalletInitialization() throws {
+    func testWalletInitialization() async throws {
         let derivationTool = DerivationTool(networkType: network.networkType)
         let ufvk = try derivationTool.deriveUnifiedSpendingKey(seed: seedData.bytes, accountIndex: 0)
             .map({ try derivationTool.deriveUnifiedFullViewingKey(from: $0) })
@@ -57,7 +57,7 @@ class WalletTests: XCTestCase {
         
         let synchronizer = SDKSynchronizer(initializer: wallet)
         do {
-            guard case .success = try synchronizer.prepare(with: seedData.bytes, viewingKeys: [ufvk], walletBirthday: 663194) else {
+            guard case .success = try await synchronizer.prepare(with: seedData.bytes, viewingKeys: [ufvk], walletBirthday: 663194) else {
                 XCTFail("Failed to initDataDb. Expected `.success` got: `.seedRequired`")
                 return
             }

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -78,7 +78,7 @@ class SynchronizerTests: XCTestCase {
             try? FileManager.default.removeItem(at: databases.pendingDB)
             
             let synchronizer = SDKSynchronizer(initializer: initializer)
-            _ = try synchronizer.prepare(with: seedBytes, viewingKeys: [ufvk], walletBirthday: birthday)
+            _ = try await synchronizer.prepare(with: seedBytes, viewingKeys: [ufvk], walletBirthday: birthday)
             
             let syncSyncedExpectation = XCTestExpectation(description: "synchronizerSynced Expectation")
             sdkSynchronizerSyncStatusHandler.subscribe(to: synchronizer.stateStream, expectations: [.synced: syncSyncedExpectation])
@@ -89,7 +89,7 @@ class SynchronizerTests: XCTestCase {
                 birthday: self.birthday + 99
             )
             
-            try synchronizer.start()
+            try await synchronizer.start()
             
             wait(for: [syncSyncedExpectation], timeout: 100)
             

--- a/Tests/TestUtils/AlternativeSynchronizerAPITestsData.swift
+++ b/Tests/TestUtils/AlternativeSynchronizerAPITestsData.swift
@@ -1,0 +1,81 @@
+//
+//  AlternativeSynchronizerAPITestsData.swift
+//
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Foundation
+@testable import ZcashLightClientKit
+
+class AlternativeSynchronizerAPITestsData {
+    let derivationTools = DerivationTool(networkType: .testnet)
+    let saplingAddress = SaplingAddress(validatedEncoding: "ztestsapling1ctuamfer5xjnnrdr3xdazenljx0mu0gutcf9u9e74tr2d3jwjnt0qllzxaplu54hgc2tyjdc2p6")
+    let unifiedAddress = UnifiedAddress(
+        validatedEncoding: """
+        u1l9f0l4348negsncgr9pxd9d3qaxagmqv3lnexcplmufpq7muffvfaue6ksevfvd7wrz7xrvn95rc5zjtn7ugkmgh5rnxswmcj30y0pw52pn0zjvy38rn2esfgve64rj5pcmazxgpyuj
+        """
+    )
+    let transparentAddress = TransparentAddress(validatedEncoding: "t1dRJRY7GmyeykJnMH38mdQoaZtFhn1QmGz")
+    lazy var pendingTransactionEntity = {
+        PendingTransaction(value: Zatoshi(10), recipient: .address(.transparent(transparentAddress)), memo: .empty(), account: 0)
+    }()
+
+    let clearedTransaction = {
+        ZcashTransaction.Overview(
+            blockTime: Date().timeIntervalSince1970,
+            expiryHeight: 123000,
+            fee: Zatoshi(10),
+            id: 333,
+            index: nil,
+            isWalletInternal: false,
+            hasChange: false,
+            memoCount: 0,
+            minedHeight: 120000,
+            raw: nil,
+            rawID: Data(),
+            receivedNoteCount: 0,
+            sentNoteCount: 0,
+            value: Zatoshi(100)
+        )
+    }()
+
+    let sentTransaction = {
+        ZcashTransaction.Sent(
+            blockTime: 1,
+            expiryHeight: nil,
+            fromAccount: 0,
+            id: 9,
+            index: 0,
+            memoCount: 0,
+            minedHeight: 0,
+            noteCount: 0,
+            raw: nil,
+            rawID: nil,
+            value: Zatoshi.zero
+        )
+    }()
+
+    let receivedTransaction = {
+        ZcashTransaction.Received(
+            blockTime: 1,
+            expiryHeight: nil,
+            fromAccount: 0,
+            id: 9,
+            index: 0,
+            memoCount: 0,
+            minedHeight: 0,
+            noteCount: 0,
+            raw: nil,
+            rawID: nil,
+            value: Zatoshi.zero
+        )
+    }()
+
+    var seed: [UInt8] = Environment.seedBytes
+    lazy var spendingKey: UnifiedSpendingKey = { try! derivationTools.deriveUnifiedSpendingKey(seed: seed, accountIndex: 0) }()
+    lazy var viewingKey: UnifiedFullViewingKey = { try! derivationTools.deriveUnifiedFullViewingKey(from: spendingKey) }()
+    var birthday: BlockHeight = 123000
+
+    init() { }
+}

--- a/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
+++ b/Tests/TestUtils/CompactBlockProcessorEventHandler.swift
@@ -27,11 +27,12 @@ class CompactBlockProcessorEventHandler {
     private let queue = DispatchQueue(label: "CompactBlockProcessorEventHandler")
     private var cancelables: [AnyCancellable] = []
 
-    func subscribe(to eventStream: AnyPublisher<CompactBlockProcessor.Event, Never>, expectations: [EventIdentifier: XCTestExpectation]) {
-        eventStream
-            .receive(on: queue)
-            .sink { event in expectations[event.identifier]?.fulfill() }
-            .store(in: &cancelables)
+    func subscribe(to blockProcessor: CompactBlockProcessor, expectations: [EventIdentifier: XCTestExpectation]) async {
+        let closure: CompactBlockProcessor.EventClosure = { event in
+            expectations[event.identifier]?.fulfill()
+        }
+
+        await blockProcessor.updateEventClosure(identifier: "CompactBlockProcessorEventHandler", closure: closure)
     }
 }
 

--- a/Tests/TestUtils/SynchronizerMock.swift
+++ b/Tests/TestUtils/SynchronizerMock.swift
@@ -1,0 +1,171 @@
+//
+//  SynchronizerMock.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Combine
+import Foundation
+@testable import ZcashLightClientKit
+
+class SynchronizerMock: Synchronizer {
+    init() { }
+
+    var underlyingStateStream: AnyPublisher<SynchronizerState, Never>! = nil
+    var stateStream: AnyPublisher<SynchronizerState, Never> { underlyingStateStream }
+
+    var underlyingLatestState: SynchronizerState! = nil
+    var latestState: SynchronizerState { underlyingLatestState }
+
+    var underlyingEventStream: AnyPublisher<SynchronizerEvent, Never>! = nil
+    var eventStream: AnyPublisher<SynchronizerEvent, Never> { underlyingEventStream }
+
+    var underlyingConnectionState: ConnectionState! = nil
+    var connectionState: ConnectionState { underlyingConnectionState }
+
+    var prepareWithSeedViewingKeysWalletBirthdayClosure: (
+        ([UInt8]?, [UnifiedFullViewingKey], BlockHeight) async throws -> Initializer.InitializationResult
+    )! = nil
+    func prepare(
+        with seed: [UInt8]?,
+        viewingKeys: [UnifiedFullViewingKey],
+        walletBirthday: BlockHeight
+    ) async throws -> Initializer.InitializationResult {
+        return try await prepareWithSeedViewingKeysWalletBirthdayClosure(seed, viewingKeys, walletBirthday)
+    }
+
+    var startRetryClosure: ((Bool) async throws -> Void)! = nil
+    func start(retry: Bool) async throws {
+        try await startRetryClosure(retry)
+    }
+
+    var stopClosure: (() async -> Void)! = nil
+    func stop() async {
+        await stopClosure()
+    }
+
+    var getSaplingAddressAccountIndexClosure: ((Int) async -> SaplingAddress?)! = nil
+    func getSaplingAddress(accountIndex: Int) async -> SaplingAddress? {
+        return await getSaplingAddressAccountIndexClosure(accountIndex)
+    }
+
+    var getUnifiedAddressAccountIndexClosure: ((Int) async -> UnifiedAddress?)! = nil
+    func getUnifiedAddress(accountIndex: Int) async -> UnifiedAddress? {
+        return await getUnifiedAddressAccountIndexClosure(accountIndex)
+    }
+
+    var getTransparentAddressAccountIndexClosure: ((Int) async -> TransparentAddress?)! = nil
+    func getTransparentAddress(accountIndex: Int) async -> TransparentAddress? {
+        return await getTransparentAddressAccountIndexClosure(accountIndex)
+    }
+
+    var sendToAddressSpendingKeyZatoshiToAddressMemoClosure: (
+        (UnifiedSpendingKey, Zatoshi, Recipient, Memo?) async throws -> PendingTransactionEntity
+    )! = nil
+    func sendToAddress(spendingKey: UnifiedSpendingKey, zatoshi: Zatoshi, toAddress: Recipient, memo: Memo?) async throws -> PendingTransactionEntity {
+        return try await sendToAddressSpendingKeyZatoshiToAddressMemoClosure(spendingKey, zatoshi, toAddress, memo)
+    }
+
+    var shieldFundsSpendingKeyMemoShieldingThresholdClosure: ((UnifiedSpendingKey, Memo, Zatoshi) async throws -> PendingTransactionEntity)! = nil
+    func shieldFunds(spendingKey: UnifiedSpendingKey, memo: Memo, shieldingThreshold: Zatoshi) async throws -> PendingTransactionEntity {
+        return try await shieldFundsSpendingKeyMemoShieldingThresholdClosure(spendingKey, memo, shieldingThreshold)
+    }
+
+    var cancelSpendTransactionClosure: ((PendingTransactionEntity) -> Bool)! = nil
+    func cancelSpend(transaction: PendingTransactionEntity) -> Bool {
+        return cancelSpendTransactionClosure(transaction)
+    }
+
+    var underlyingPendingTransactions: [PendingTransactionEntity]! = nil
+    var pendingTransactions: [PendingTransactionEntity] { underlyingPendingTransactions }
+
+    var underlyingClearedTransactions: [ZcashTransaction.Overview]! = nil
+    var clearedTransactions: [ZcashTransaction.Overview] { underlyingClearedTransactions }
+
+    var underlyingSentTransactions: [ZcashTransaction.Sent]! = nil
+    var sentTransactions: [ZcashTransaction.Sent] { underlyingSentTransactions }
+
+    var underlyingReceivedTransactions: [ZcashTransaction.Received]! = nil
+    var receivedTransactions: [ZcashTransaction.Received] { underlyingReceivedTransactions }
+
+    var paginatedTransactionsOfKindClosure: ((TransactionKind) -> PaginatedTransactionRepository)! = nil
+    func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository {
+        return paginatedTransactionsOfKindClosure(kind)
+    }
+
+    var getMemosForTransactionClosure: ((ZcashTransaction.Overview) throws -> [Memo])! = nil
+    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] {
+        return try getMemosForTransactionClosure(transaction)
+    }
+
+    var getMemosForReceivedTransactionClosure: ((ZcashTransaction.Received) throws -> [Memo])! = nil
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] {
+        return try getMemosForReceivedTransactionClosure(receivedTransaction)
+    }
+
+    var getMemosForSentTransactionClosure: ((ZcashTransaction.Sent) throws -> [Memo])! = nil
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] {
+        return try getMemosForSentTransactionClosure(sentTransaction)
+    }
+
+    var getRecipientsForClearedTransactionClosure: ((ZcashTransaction.Overview) -> [TransactionRecipient])! = nil
+    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] {
+        return getRecipientsForClearedTransactionClosure(transaction)
+    }
+
+    var getRecipientsForSentTransactionClosure: ((ZcashTransaction.Sent) -> [TransactionRecipient])! = nil
+    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] {
+        return getRecipientsForSentTransactionClosure(transaction)
+    }
+
+    var allConfirmedTransactionsFromTransactionClosure: ((ZcashTransaction.Overview, Int) throws -> [ZcashTransaction.Overview])! = nil
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
+        return try allConfirmedTransactionsFromTransactionClosure(transaction, limit)
+    }
+
+    var latestHeightClosure: (() async throws -> BlockHeight)! = nil
+    func latestHeight() async throws -> BlockHeight {
+        return try await latestHeightClosure()
+    }
+
+    var refreshUTXOsAddressFromHeightClosure: ((TransparentAddress, BlockHeight) async throws -> RefreshedUTXOs)! = nil
+    func refreshUTXOs(address: TransparentAddress, from height: BlockHeight) async throws -> RefreshedUTXOs {
+        return try await refreshUTXOsAddressFromHeightClosure(address, height)
+    }
+
+    var getTransparentBalanceAccountIndexClosure: ((Int) async throws -> WalletBalance)! = nil
+    func getTransparentBalance(accountIndex: Int) async throws -> WalletBalance {
+        return try await getTransparentBalanceAccountIndexClosure(accountIndex)
+    }
+
+    var getShieldedBalanceAccountIndexDeprecatedClosure: ((Int) -> Int64)! = nil
+    func getShieldedBalance(accountIndex: Int) -> Int64 {
+        return getShieldedBalanceAccountIndexDeprecatedClosure(accountIndex)
+    }
+
+    var getShieldedBalanceAccountIndexClosure: ((Int) -> Zatoshi)! = nil
+    func getShieldedBalance(accountIndex: Int) -> Zatoshi {
+        return getShieldedBalanceAccountIndexClosure(accountIndex)
+    }
+
+    var getShieldedVerifiedBalanceAccountIndexDeprecatedClosure: ((Int) -> Int64)! = nil
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Int64 {
+        return getShieldedVerifiedBalanceAccountIndexDeprecatedClosure(accountIndex)
+    }
+
+    var getShieldedVerifiedBalanceAccountIndexClosure: ((Int) -> Zatoshi)! = nil
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi {
+        return getShieldedVerifiedBalanceAccountIndexClosure(accountIndex)
+    }
+
+    var rewindPolicyClosure: ((RewindPolicy) -> AnyPublisher<Void, Error>)! = nil
+    func rewind(_ policy: RewindPolicy) -> AnyPublisher<Void, Error> {
+        return rewindPolicyClosure(policy)
+    }
+
+    var wipeClosure: (() -> AnyPublisher<Void, Error>)! = nil
+    func wipe() -> AnyPublisher<Void, Error> {
+        return wipeClosure()
+    }
+}

--- a/Tests/TestUtils/UnspentTransactionOutputEntityMock.swift
+++ b/Tests/TestUtils/UnspentTransactionOutputEntityMock.swift
@@ -1,0 +1,37 @@
+//
+//  UnspentTransactionOutputEntityMock.swift
+//  
+//
+//  Created by Michal Fousek on 20.03.2023.
+//
+
+import Foundation
+@testable import ZcashLightClientKit
+
+class UnspentTransactionOutputEntityMock: UnspentTransactionOutputEntity, Equatable {
+    var address: String
+    var txid: Data
+    var index: Int
+    var script: Data
+    var valueZat: Int
+    var height: Int
+
+    init(address: String, txid: Data, index: Int, script: Data, valueZat: Int, height: Int) {
+        self.address = address
+        self.txid = txid
+        self.index = index
+        self.script = script
+        self.valueZat = valueZat
+        self.height = height
+    }
+
+    static func == (lhs: UnspentTransactionOutputEntityMock, rhs: UnspentTransactionOutputEntityMock) -> Bool {
+        return
+            lhs.address == rhs.address &&
+            lhs.txid == rhs.txid &&
+            lhs.index == rhs.index &&
+            lhs.script == rhs.script &&
+            lhs.valueZat == rhs.valueZat &&
+            lhs.height == rhs.height
+    }
+}

--- a/Tests/TestUtils/XCAsyncTestCase.swift
+++ b/Tests/TestUtils/XCAsyncTestCase.swift
@@ -14,7 +14,7 @@ extension XCTestCase {
     static func wait(asyncBlock: @escaping (() async throws -> Void)) {
         let semaphore = DispatchSemaphore(value: 0)
         Task.init {
-            try await asyncBlock()
+            try! await asyncBlock()
             semaphore.signal()
         }
         semaphore.wait()


### PR DESCRIPTION
Closes #831.

This change introduces two new protocols: `ClosureSynchronizer` and
`CombineSynchronizer`. These two protocols define API that doesn't use
`async`. So the client can choose exactly which API it wants to use.

This change also introduces two new objects: `ClosureSDKSynchronizer`
and `CombineSDKSynchronizer`. These two implement the respective protocols
mentioned above. Both are structures. Neither of these two keeps any state.
Thanks to this each is very cheap to create. And usage of these two isn't
mutually exclusive. So devs can really choose the best SDK API for each
part of the client app.

[#831] Use async inside of the SDKSynchronizer

- In general lot of methods inside the `SDKSynchronizer` and
  `CompactBlockProcessoer` which weren't async are now async. And other
  changes are made because of this change.
- `CompactBlockProcessor` no longer uses Combine to communicate with
  `SDKSynchronizer`. Reason for this is that Combine doesn't play great
  with async. Closure passed to `sink` isn't async.
- Because of this and because of how our tests work (receiving signals
  from CBP directly) `CompactBlockProcessor` must be able to handle more
  event closures. Not just one. So it now has `eventClosures`
  dictionary. It's little bit strange but it works fine.
- `SyncStatus` inside the `SDKSynchronizer` was previously protected by
  lock. Now it's protected by simple actor wrapper.
- Changes in tests are minimal. Changes were mady only because
  `CompactBlockProcessor` changes from Combine to closures.

[#831] Add tests for ClosureSDKSynchronizer

- Added tests are testing in general if the `ClosuresSDKSynchronizer` is correctly
  calling `Synchronizer` and if the values are correctly returned.
- `ClosuresSDKSynchronizer` doesn't contain any logic but it is public
  API and we should be sure that it works correctly.

[#831] Add tests for CombineSDKSynchronizer

[#831] Add changelog

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.

# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.