### PR TITLE
[#851] Apply the Alias to the URLs

### DIFF
--- a/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return wallet
         } else {
             let wallet = Initializer(
+                cacheDbURL: nil,
                 fsBlockDbRoot: try! fsBlockDbRootURLHelper(),
                 dataDbURL: try! dataDbURLHelper(),
                 pendingDbURL: try! pendingDbURLHelper(),

--- a/Sources/ZcashLightClientKit/Extensions/URL+UpdateWithAlias.swift
+++ b/Sources/ZcashLightClientKit/Extensions/URL+UpdateWithAlias.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by Michal Fousek on 23.03.2023.
+//
+
+import Foundation
+
+extension URL {
+    /// Try to update URLs with `alias`.
+    ///
+    /// If the `default` alias is used then the URL isn't changed at all.
+    /// If the `custom("anotherInstance")` is used then last path component or the URL is updated like this:
+    /// - /some/path/to.file -> /some/path/c_anotherInstance_to.file
+    /// - /some/path/to/directory -> /some/path/to/c_anotherInstance_directory
+    ///
+    /// If the URLs can't be parsed then `nil` is returned.
+    func updateLastPathComponent(with alias: ZcashSynchronizerAlias) -> URL? {
+        let lastPathComponent = self.lastPathComponent
+        guard !lastPathComponent.isEmpty else {
+            return nil
+        }
+
+        switch alias {
+        case .`default`:
+            // When using default alias everything should work as before aliases to be backwards compatible.
+            return self
+
+        case .custom:
+            let newLastPathComponent = "\(alias.description)_\(lastPathComponent)"
+            return self.deletingLastPathComponent()
+                .appendingPathComponent(newLastPathComponent)
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -129,6 +129,9 @@ public protocol Synchronizer: AnyObject {
     /// `InitializerError.dataDbInitFailed` if the creation of the dataDb fails
     /// `InitializerError.accountInitFailed` if the account table can't be initialized.
     /// `InitializerError.aliasAlreadyInUse` if the Alias used to create this instance is already used by other instance
+    /// `InitializerError.cantUpdateURLWithAlias` if the updating of paths in `Initilizer` according to alias fails. When this happens it means that
+    ///                                           some path passed to `Initializer` is invalid. The SDK can't recover from this and this instance
+    ///                                           won't do anything.
     func prepare(
         with seed: [UInt8]?,
         viewingKeys: [UnifiedFullViewingKey],
@@ -299,6 +302,10 @@ public protocol Synchronizer: AnyObject {
     ///
     /// Returned publisher emits `InitializerError.aliasAlreadyInUse` error if the Alias used to create this instance is already used by other
     /// instance.
+    ///
+    /// Returned publisher emits `InitializerError.cantUpdateURLWithAlias` if the updating of paths in `Initilizer` according to alias fails. When
+    /// this happens it means that some path passed to `Initializer` is invalid. The SDK can't recover from this and this instance won't do anything.
+    /// 
     func wipe() -> AnyPublisher<Void, Error>
 }
 

--- a/Tests/OfflineTests/InitializerOfflineTests.swift
+++ b/Tests/OfflineTests/InitializerOfflineTests.swift
@@ -1,0 +1,231 @@
+//
+//  InitializerOfflineTests.swift
+//  
+//
+//  Created by Michal Fousek on 24.03.2023.
+//
+
+import Foundation
+@testable import TestUtils
+import XCTest
+@testable import ZcashLightClientKit
+
+class InitializerOfflineTests: XCTestCase {
+    let validFileURL = URL(fileURLWithPath: "/some/valid/path/to.file")
+    let validDirectoryURL = URL(fileURLWithPath: "/some/valid/path/to/directory")
+    let invalidPathURL = URL(string: "https://whatever")!
+
+    // MARK: - Utils
+
+    private func makeInitializer(
+        fsBlockDbRoot: URL,
+        dataDbURL: URL,
+        pendingDbURL: URL,
+        spendParamsURL: URL,
+        outputParamsURL: URL,
+        alias: ZcashSynchronizerAlias
+    ) -> Initializer {
+        return Initializer(
+            cacheDbURL: nil,
+            fsBlockDbRoot: fsBlockDbRoot,
+            dataDbURL: dataDbURL,
+            pendingDbURL: pendingDbURL,
+            endpoint: LightWalletEndpointBuilder.default,
+            network: ZcashNetworkBuilder.network(for: .testnet),
+            spendParamsURL: spendParamsURL,
+            outputParamsURL: outputParamsURL,
+            saplingParamsSourceURL: .default,
+            alias: alias,
+            loggerProxy: nil
+        )
+    }
+
+    private func update(url: URL, with alias: ZcashSynchronizerAlias) -> URL {
+        guard alias != .default else { return url }
+        let lastPathComponent = url.lastPathComponent
+        guard !lastPathComponent.isEmpty else { return url }
+        return url
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(alias.description)_\(lastPathComponent)")
+    }
+
+    // MARK: - Tests
+
+    private func genericTestForURLsParsingFailures(
+        fsBlockDbRoot: URL,
+        dataDbURL: URL,
+        pendingDbURL: URL,
+        spendParamsURL: URL,
+        outputParamsURL: URL,
+        alias: ZcashSynchronizerAlias,
+        function: String = #function
+    ) {
+        let initializer = makeInitializer(
+            fsBlockDbRoot: fsBlockDbRoot,
+            dataDbURL: dataDbURL,
+            pendingDbURL: pendingDbURL,
+            spendParamsURL: spendParamsURL,
+            outputParamsURL: outputParamsURL,
+            alias: alias
+        )
+
+        if let error = initializer.urlsParsingError, case let .cantUpdateURLWithAlias(failedURL) = error {
+            XCTAssertEqual(failedURL, invalidPathURL, "Failing \(function)")
+        } else {
+            XCTFail("URLs parsing error expected. Failing \(function)")
+        }
+
+        XCTAssertEqual(initializer.fsBlockDbRoot, fsBlockDbRoot, "Failing \(function)")
+        XCTAssertEqual(initializer.dataDbURL, dataDbURL, "Failing \(function)")
+        XCTAssertEqual(initializer.pendingDbURL, pendingDbURL, "Failing \(function)")
+        XCTAssertEqual(initializer.spendParamsURL, spendParamsURL, "Failing \(function)")
+        XCTAssertEqual(initializer.outputParamsURL, outputParamsURL, "Failing \(function)")
+    }
+
+    func test__defaultAlias__validURLs__updatedURLsAreBackwardsCompatible() {
+        let initializer = makeInitializer(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .default
+        )
+
+        XCTAssertNil(initializer.urlsParsingError)
+        XCTAssertEqual(initializer.fsBlockDbRoot, validDirectoryURL)
+        XCTAssertEqual(initializer.dataDbURL, validFileURL)
+        XCTAssertEqual(initializer.pendingDbURL, validFileURL)
+        XCTAssertEqual(initializer.spendParamsURL, validFileURL)
+        XCTAssertEqual(initializer.outputParamsURL, validFileURL)
+    }
+
+    func test__defaultAlias__invalidFsBlockDbRootURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: invalidPathURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .default
+        )
+    }
+
+    func test__defaultAlias__invalidDataDbURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: invalidPathURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .default
+        )
+    }
+
+    func test__defaultAlias__invalidPendingDbURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: invalidPathURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .default
+        )
+    }
+
+    func test__defaultAlias__invalidSpendParamsURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: invalidPathURL,
+            outputParamsURL: validFileURL,
+            alias: .default
+        )
+    }
+
+    func test__defaultAlias__invalidOutputParamsURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: invalidPathURL,
+            alias: .default
+        )
+    }
+
+    func test__customAlias__validURLs__updatedURLsAreAsExpected() {
+        let alias: ZcashSynchronizerAlias = .custom("alias")
+        let initializer = makeInitializer(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: alias
+        )
+
+        XCTAssertNil(initializer.urlsParsingError)
+        XCTAssertEqual(initializer.fsBlockDbRoot, update(url: validDirectoryURL, with: alias))
+        XCTAssertEqual(initializer.dataDbURL, update(url: validFileURL, with: alias))
+        XCTAssertEqual(initializer.pendingDbURL, update(url: validFileURL, with: alias))
+        XCTAssertEqual(initializer.spendParamsURL, update(url: validFileURL, with: alias))
+        XCTAssertEqual(initializer.outputParamsURL, update(url: validFileURL, with: alias))
+    }
+
+    func test__customAlias__invalidFsBlockDbRootURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: invalidPathURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .custom("alias")
+        )
+    }
+
+    func test__customAlias__invalidDataDbURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: invalidPathURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .custom("alias")
+        )
+    }
+
+    func test__customAlias__invalidPendingDbURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: invalidPathURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
+            alias: .custom("alias")
+        )
+    }
+
+    func test__customAlias__invalidSpendParamsURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: invalidPathURL,
+            outputParamsURL: validFileURL,
+            alias: .custom("alias")
+        )
+    }
+
+    func test__customAlias__invalidOutputParamsURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            pendingDbURL: validFileURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: invalidPathURL,
+            alias: .custom("alias")
+        )
+    }
+}

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -45,6 +45,7 @@ class WalletTests: XCTestCase {
             .map({ try derivationTool.deriveUnifiedFullViewingKey(from: $0) })
 
         let wallet = Initializer(
+            cacheDbURL: nil,
             fsBlockDbRoot: self.testTempDirectory,
             dataDbURL: try __dataDbURL(),
             pendingDbURL: try TestDbBuilder.pendingTransactionsDbURL(),
@@ -64,7 +65,7 @@ class WalletTests: XCTestCase {
         } catch {
             XCTFail("shouldn't fail here. Got error: \(error)")
         }
-        
+
         // fileExists actually sucks, so attempting to delete the file and checking what happens is far better :)
         XCTAssertNoThrow( try FileManager.default.removeItem(at: dbData!) )
     }

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -61,6 +61,7 @@ class SynchronizerTests: XCTestCase {
         for _ in 1...5 {
             let databases = TemporaryDbBuilder.build()
             let initializer = Initializer(
+                cacheDbURL: nil,
                 fsBlockDbRoot: databases.fsCacheDbRoot,
                 dataDbURL: databases.dataDB,
                 pendingDbURL: databases.pendingDB,

--- a/Tests/TestUtils/TestCoordinator.swift
+++ b/Tests/TestUtils/TestCoordinator.swift
@@ -356,6 +356,7 @@ enum TestSynchronizerBuilder {
         loggerProxy: Logger? = nil
     ) -> SDKSynchronizer {
         let initializer = Initializer(
+            cacheDbURL: nil,
             fsBlockDbRoot: fsBlockDbRoot,
             dataDbURL: dataDbURL,
             pendingDbURL: pendingDbURL,


### PR DESCRIPTION
Closes #851.

- `Initializer` now updates paths according to alias before paths are used anywhere in the SDK.
- Paths update can fail. It would be incovenient for the client apps to handle errors thrown from `Initiliazer` constructor. So the error is then handled in `SDKSynchronizer.prepare()` or `SDKSynchronizer.wipe()`.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.