### PR TITLE
[#484] Use async for TransactionsRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ These methods in the `SDKSynchronizer` are now async:
 - `prepare(with:viewingKeys:walletBirthday:)`
 - `start(retry:)`
 - `stop()`
+- `cancelSpend(transaction:)`
+- All the variants of the `getMemos(for:)` method.
+- All the variants fo the `getRecipients(for:)` method.
+- `allConfirmedTransactions(from:limit:)`
+
+These properties in the `SDKSynchronizer` are now async:
+- `pendingTransactions`
+- `clearedTransactions`
+- `sentTransactions`
+- `receivedTransactions`
 
 Non async `SDKsynchronizer.latestHeight(result:)` were moved to `ClosureSDKSynchronizer`.
 

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/DemoAppConfig.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/DemoAppConfig.swift
@@ -20,7 +20,6 @@ enum DemoAppConfig {
 
     static var host = ZcashSDK.isMainnet ? "lightwalletd.electriccoin.co" : "lightwalletd.testnet.electriccoin.co"
     static var port: Int = 9067
-
     static var defaultBirthdayHeight: BlockHeight = ZcashSDK.isMainnet ? 935000 : 1386000
     static var defaultSeed = try! Mnemonic.deterministicSeedBytes(from: """
     live combine flight accident slow soda mind bright absent bid hen shy decade biology amazing mix enlist ensure biology rhythm snap duty soap armor

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/List Transactions/TransactionsTableViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/List Transactions/TransactionsTableViewController.swift
@@ -13,9 +13,13 @@ class TransactionsTableViewController: UITableViewController {
     var datasource: TransactionsDataSource? {
         didSet {
             self.tableView.dataSource = datasource
-            try? datasource?.load()
-            if viewIfLoaded != nil {
-                self.tableView.reloadData()
+            Task {
+                try? await datasource?.load()
+                DispatchQueue.main.async { [weak self] in
+                    if self?.viewIfLoaded != nil {
+                        self?.tableView.reloadData()
+                    }
+                }
             }
         }
     }
@@ -26,8 +30,14 @@ class TransactionsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.dataSource = datasource
-        try? datasource?.load()
         self.tableView.reloadData()
+
+        Task {
+            try? await datasource?.load()
+            DispatchQueue.main.async { [weak self] in
+                self?.tableView.reloadData()
+            }
+        }
     }
 }
 

--- a/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
+++ b/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
@@ -56,7 +56,7 @@ struct BlockEnhancerImpl {
 
         let confirmedTx: ZcashTransaction.Overview
         do {
-            confirmedTx = try transactionRepository.find(rawID: fetchedTransaction.rawID)
+            confirmedTx = try await transactionRepository.find(rawID: fetchedTransaction.rawID)
         } catch {
             if let err = error as? TransactionRepositoryError, case .notFound = err {
                 throw BlockEnhancerError.txIdNotFound(txId: fetchedTransaction.rawID)
@@ -88,7 +88,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
         // fetch transactions
         do {
             let startTime = Date()
-            let transactions = try transactionRepository.find(in: range, limit: Int.max, kind: .all)
+            let transactions = try await transactionRepository.find(in: range, limit: Int.max, kind: .all)
 
             guard !transactions.isEmpty else {
                 await internalSyncProgress.set(range.upperBound, .latestEnhancedHeight)
@@ -148,6 +148,6 @@ extension BlockEnhancerImpl: BlockEnhancer {
             logger.debug("Warning: compactBlockEnhancement on range \(range) cancelled")
         }
 
-        return (try? transactionRepository.find(in: range, limit: Int.max, kind: .all)) ?? []
+        return (try? await transactionRepository.find(in: range, limit: Int.max, kind: .all)) ?? []
     }
 }

--- a/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
+++ b/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
@@ -30,7 +30,7 @@ extension BlockScannerImpl: BlockScanner {
     func scanBlocks(at range: CompactBlockRange, totalProgressRange: CompactBlockRange, didScan: @escaping (BlockHeight) async -> Void) async throws {
         try Task.checkCancellation()
 
-        let scanStartHeight = try transactionRepository.lastScannedHeight()
+        let scanStartHeight = try await transactionRepository.lastScannedHeight()
         let targetScanHeight = range.upperBound
 
         var scannedNewBlocks = false
@@ -57,7 +57,7 @@ extension BlockScannerImpl: BlockScanner {
             }
             let scanFinishTime = Date()
 
-            lastScannedHeight = try transactionRepository.lastScannedHeight()
+            lastScannedHeight = try await transactionRepository.lastScannedHeight()
 
             scannedNewBlocks = previousScannedHeight != lastScannedHeight
             if scannedNewBlocks {

--- a/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/AfterSyncHooksManager.swift
@@ -16,7 +16,7 @@ class AfterSyncHooksManager {
 
     struct RewindContext {
         let height: BlockHeight?
-        let completion: (Result<BlockHeight, Error>) -> Void
+        let completion: (Result<BlockHeight, Error>) async -> Void
     }
 
     enum Hook: Equatable, Hashable {

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -51,23 +51,27 @@ public protocol ClosureSynchronizer {
         completion: @escaping (Result<PendingTransactionEntity, Error>) -> Void
     )
 
-    func cancelSpend(transaction: PendingTransactionEntity) -> Bool
+    func cancelSpend(transaction: PendingTransactionEntity, completion: @escaping (Bool) -> Void)
 
-    var pendingTransactions: [PendingTransactionEntity] { get }
-    var clearedTransactions: [ZcashTransaction.Overview] { get }
-    var sentTransactions: [ZcashTransaction.Sent] { get }
-    var receivedTransactions: [ZcashTransaction.Received] { get }
-    
+    func pendingTransactions(completion: @escaping ([PendingTransactionEntity]) -> Void)
+    func clearedTransactions(completion: @escaping ([ZcashTransaction.Overview]) -> Void)
+    func sentTranscations(completion: @escaping ([ZcashTransaction.Sent]) -> Void)
+    func receivedTransactions(completion: @escaping ([ZcashTransaction.Received]) -> Void)
+
     func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository
 
-    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
-    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
-    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
+    func getMemos(for transaction: ZcashTransaction.Overview, completion: @escaping (Result<[Memo], Error>) -> Void)
+    func getMemos(for receivedTransaction: ZcashTransaction.Received, completion: @escaping (Result<[Memo], Error>) -> Void)
+    func getMemos(for sentTransaction: ZcashTransaction.Sent, completion: @escaping (Result<[Memo], Error>) -> Void)
 
-    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient]
-    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Overview, completion: @escaping ([TransactionRecipient]) -> Void)
+    func getRecipients(for transaction: ZcashTransaction.Sent, completion: @escaping ([TransactionRecipient]) -> Void)
 
-    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
+    func allConfirmedTransactions(
+        from transaction: ZcashTransaction.Overview,
+        limit: Int,
+        completion: @escaping (Result<[ZcashTransaction.Overview], Error>) -> Void
+    )
 
     func latestHeight(completion: @escaping (Result<BlockHeight, Error>) -> Void)
 

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -55,23 +55,23 @@ public protocol CombineSynchronizer {
         shieldingThreshold: Zatoshi
     ) -> Single<PendingTransactionEntity, Error>
 
-    func cancelSpend(transaction: PendingTransactionEntity) -> Bool
+    func cancelSpend(transaction: PendingTransactionEntity) -> Single<Bool, Never>
 
-    var pendingTransactions: [PendingTransactionEntity] { get }
-    var clearedTransactions: [ZcashTransaction.Overview] { get }
-    var sentTransactions: [ZcashTransaction.Sent] { get }
-    var receivedTransactions: [ZcashTransaction.Received] { get }
-    
+    var pendingTransactions: Single<[PendingTransactionEntity], Never> { get }
+    var clearedTransactions: Single<[ZcashTransaction.Overview], Never> { get }
+    var sentTransactions: Single<[ZcashTransaction.Sent], Never> { get }
+    var receivedTransactions: Single<[ZcashTransaction.Received], Never> { get }
+
     func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository
 
-    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
-    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
-    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
+    func getMemos(for transaction: ZcashTransaction.Overview) -> Single<[Memo], Error>
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) -> Single<[Memo], Error>
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) -> Single<[Memo], Error>
 
-    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient]
-    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Overview) -> Single<[TransactionRecipient], Never>
+    func getRecipients(for transaction: ZcashTransaction.Sent) -> Single<[TransactionRecipient], Never>
 
-    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) -> Single<[ZcashTransaction.Overview], Error>
 
     func latestHeight() -> Single<BlockHeight, Error>
 

--- a/Sources/ZcashLightClientKit/Repository/PaginatedTransactionRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/PaginatedTransactionRepository.swift
@@ -16,17 +16,17 @@ public protocol PaginatedTransactionRepository {
     /**
     How many pages are in total
     */
-    var pageCount: Int { get }
+    var pageCount: Int { get async }
     
     /**
     How many items are to be displayed in total
     */
-    var itemCount: Int { get }
+    var itemCount: Int { get async }
 
     /**
     Returns the page number if exists. Blocking
     */
-    func page(_ number: Int) throws -> [ZcashTransaction.Overview]?
+    func page(_ number: Int) async throws -> [ZcashTransaction.Overview]?
     
     /**
     Returns the page number if exists. Non-blocking

--- a/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/TransactionRepository.swift
@@ -15,20 +15,20 @@ enum TransactionRepositoryError: Error {
 
 protocol TransactionRepository {
     func closeDBConnection()
-    func countAll() throws -> Int
-    func countUnmined() throws -> Int
-    func blockForHeight(_ height: BlockHeight) throws -> Block?
-    func lastScannedHeight() throws -> BlockHeight
-    func isInitialized() throws -> Bool
-    func find(id: Int) throws -> ZcashTransaction.Overview
-    func find(rawID: Data) throws -> ZcashTransaction.Overview
-    func find(offset: Int, limit: Int, kind: TransactionKind) throws -> [ZcashTransaction.Overview]
-    func find(in range: CompactBlockRange, limit: Int, kind: TransactionKind) throws -> [ZcashTransaction.Overview]
-    func find(from: ZcashTransaction.Overview, limit: Int, kind: TransactionKind) throws -> [ZcashTransaction.Overview]
-    func findReceived(offset: Int, limit: Int) throws -> [ZcashTransaction.Received]
-    func findSent(offset: Int, limit: Int) throws -> [ZcashTransaction.Sent]
-    func findMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
-    func findMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
-    func findMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
-    func getRecipients(for id: Int) -> [TransactionRecipient]
+    func countAll() async throws -> Int
+    func countUnmined() async throws -> Int
+    func blockForHeight(_ height: BlockHeight) async throws -> Block?
+    func lastScannedHeight() async throws -> BlockHeight
+    func isInitialized() async throws -> Bool
+    func find(id: Int) async throws -> ZcashTransaction.Overview
+    func find(rawID: Data) async throws -> ZcashTransaction.Overview
+    func find(offset: Int, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview]
+    func find(in range: CompactBlockRange, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview]
+    func find(from: ZcashTransaction.Overview, limit: Int, kind: TransactionKind) async throws -> [ZcashTransaction.Overview]
+    func findReceived(offset: Int, limit: Int) async throws -> [ZcashTransaction.Received]
+    func findSent(offset: Int, limit: Int) async throws -> [ZcashTransaction.Sent]
+    func findMemos(for transaction: ZcashTransaction.Overview) async throws -> [Memo]
+    func findMemos(for receivedTransaction: ZcashTransaction.Received) async throws -> [Memo]
+    func findMemos(for sentTransaction: ZcashTransaction.Sent) async throws -> [Memo]
+    func getRecipients(for id: Int) async -> [TransactionRecipient]
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -199,51 +199,51 @@ public protocol Synchronizer: AnyObject {
     /// an option if the transaction has not yet been submitted to the server.
     /// - Parameter transaction: the transaction to cancel.
     /// - Returns: true when the cancellation request was successful. False when it is too late.
-    func cancelSpend(transaction: PendingTransactionEntity) -> Bool
+    func cancelSpend(transaction: PendingTransactionEntity) async -> Bool
 
     /// all outbound pending transactions that have been sent but are awaiting confirmations
-    var pendingTransactions: [PendingTransactionEntity] { get }
+    var pendingTransactions: [PendingTransactionEntity] { get async }
 
     /// all the transactions that are on the blockchain
-    var clearedTransactions: [ZcashTransaction.Overview] { get }
+    var clearedTransactions: [ZcashTransaction.Overview] { get async }
 
     /// All transactions that are related to sending funds
-    var sentTransactions: [ZcashTransaction.Sent] { get }
+    var sentTransactions: [ZcashTransaction.Sent] { get async }
 
     /// all transactions related to receiving funds
-    var receivedTransactions: [ZcashTransaction.Received] { get }
+    var receivedTransactions: [ZcashTransaction.Received] { get async }
     
     /// A repository serving transactions in a paginated manner
     /// - Parameter kind: Transaction Kind expected from this PaginatedTransactionRepository
     func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository
 
     /// Get all memos for `transaction`.
-    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo]
+    func getMemos(for transaction: ZcashTransaction.Overview) async throws -> [Memo]
 
     /// Get all memos for `receivedTransaction`.
-    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo]
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) async throws -> [Memo]
 
     /// Get all memos for `sentTransaction`.
-    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo]
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) async throws -> [Memo]
 
     /// Attempt to get recipients from a Transaction Overview.
     /// - parameter transaction: A transaction overview
     /// - returns the recipients or an empty array if no recipients are found on this transaction because it's not an outgoing
     /// transaction
-    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Overview) async -> [TransactionRecipient]
     
     /// Get the recipients for the given a sent transaction
     /// - parameter transaction: A transaction overview
     /// - returns the recipients or an empty array if no recipients are found on this transaction because it's not an outgoing
     /// transaction
-    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient]
+    func getRecipients(for transaction: ZcashTransaction.Sent) async -> [TransactionRecipient]
 
     /// Returns a list of confirmed transactions that preceed the given transaction with a limit count.
     /// - Parameters:
     ///     - from: the confirmed transaction from which the query should start from or nil to retrieve from the most recent transaction
     ///     - limit: the maximum amount of items this should return if available
     ///     - Returns: an array with the given Transactions or nil
-    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview]
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) async throws -> [ZcashTransaction.Overview]
 
     /// Returns the latest block height from the provided Lightwallet endpoint
     /// Blocking

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -95,24 +95,76 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         }
     }
 
-    public func cancelSpend(transaction: PendingTransactionEntity) -> Bool { synchronizer.cancelSpend(transaction: transaction) }
+    public func cancelSpend(transaction: PendingTransactionEntity, completion: @escaping (Bool) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.cancelSpend(transaction: transaction)
+        }
+    }
 
-    public var pendingTransactions: [PendingTransactionEntity] { synchronizer.pendingTransactions }
-    public var clearedTransactions: [ZcashTransaction.Overview] { synchronizer.clearedTransactions }
-    public var sentTransactions: [ZcashTransaction.Sent] { synchronizer.sentTransactions }
-    public var receivedTransactions: [ZcashTransaction.Received] { synchronizer.receivedTransactions }
+    public func pendingTransactions(completion: @escaping ([PendingTransactionEntity]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.pendingTransactions
+        }
+    }
+
+    public func clearedTransactions(completion: @escaping ([ZcashTransaction.Overview]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.clearedTransactions
+        }
+    }
+
+    public func sentTranscations(completion: @escaping ([ZcashTransaction.Sent]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.sentTransactions
+        }
+    }
+
+    public func receivedTransactions(completion: @escaping ([ZcashTransaction.Received]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.receivedTransactions
+        }
+    }
     
     public func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository { synchronizer.paginatedTransactions(of: kind) }
 
-    public func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] { try synchronizer.getMemos(for: transaction) }
-    public func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] { try synchronizer.getMemos(for: receivedTransaction) }
-    public func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] { try synchronizer.getMemos(for: sentTransaction) }
+    public func getMemos(for transaction: ZcashTransaction.Overview, completion: @escaping (Result<[Memo], Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getMemos(for: transaction)
+        }
+    }
 
-    public func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
-    public func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+    public func getMemos(for receivedTransaction: ZcashTransaction.Received, completion: @escaping (Result<[Memo], Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getMemos(for: receivedTransaction)
+        }
+    }
 
-    public func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
-        try synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+    public func getMemos(for sentTransaction: ZcashTransaction.Sent, completion: @escaping (Result<[Memo], Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getMemos(for: sentTransaction)
+        }
+    }
+
+    public func getRecipients(for transaction: ZcashTransaction.Overview, completion: @escaping ([TransactionRecipient]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.getRecipients(for: transaction)
+        }
+    }
+
+    public func getRecipients(for transaction: ZcashTransaction.Sent, completion: @escaping ([TransactionRecipient]) -> Void) {
+        executeAction(completion) {
+            await self.synchronizer.getRecipients(for: transaction)
+        }
+    }
+
+    public func allConfirmedTransactions(
+        from transaction: ZcashTransaction.Overview,
+        limit: Int,
+        completion: @escaping (Result<[ZcashTransaction.Overview], Error>) -> Void
+    ) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+        }
     }
 
     public func latestHeight(completion: @escaping (Result<BlockHeight, Error>) -> Void) {

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -92,24 +92,72 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         }
     }
 
-    public func cancelSpend(transaction: PendingTransactionEntity) -> Bool { synchronizer.cancelSpend(transaction: transaction) }
+    public func cancelSpend(transaction: PendingTransactionEntity) -> Single<Bool, Never> {
+        executeAction() {
+            await self.synchronizer.cancelSpend(transaction: transaction)
+        }
+    }
 
-    public var pendingTransactions: [PendingTransactionEntity] { synchronizer.pendingTransactions }
-    public var clearedTransactions: [ZcashTransaction.Overview] { synchronizer.clearedTransactions }
-    public var sentTransactions: [ZcashTransaction.Sent] { synchronizer.sentTransactions }
-    public var receivedTransactions: [ZcashTransaction.Received] { synchronizer.receivedTransactions }
+    public var pendingTransactions: Single<[PendingTransactionEntity], Never> {
+        executeAction() {
+            await self.synchronizer.pendingTransactions
+        }
+    }
+
+    public var clearedTransactions: Single<[ZcashTransaction.Overview], Never> {
+        executeAction() {
+            await self.synchronizer.clearedTransactions
+        }
+    }
+
+    public var sentTransactions: Single<[ZcashTransaction.Sent], Never> {
+        executeAction() {
+            await self.synchronizer.sentTransactions
+        }
+    }
+
+    public var receivedTransactions: Single<[ZcashTransaction.Received], Never> {
+        executeAction() {
+            await self.synchronizer.receivedTransactions
+        }
+    }
     
     public func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository { synchronizer.paginatedTransactions(of: kind) }
 
-    public func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] { try synchronizer.getMemos(for: transaction) }
-    public func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] { try synchronizer.getMemos(for: receivedTransaction) }
-    public func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] { try synchronizer.getMemos(for: sentTransaction) }
+    public func getMemos(for transaction: ZcashTransaction.Overview) -> Single<[Memo], Error> {
+        executeThrowingAction() {
+            try await self.synchronizer.getMemos(for: transaction)
+        }
+    }
 
-    public func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
-    public func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] { synchronizer.getRecipients(for: transaction) }
+    public func getMemos(for receivedTransaction: ZcashTransaction.Received) -> Single<[Memo], Error> {
+        executeThrowingAction() {
+            try await self.synchronizer.getMemos(for: receivedTransaction)
+        }
+    }
 
-    public func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
-        try synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+    public func getMemos(for sentTransaction: ZcashTransaction.Sent) -> Single<[Memo], Error> {
+        executeThrowingAction() {
+            try await self.synchronizer.getMemos(for: sentTransaction)
+        }
+    }
+
+    public func getRecipients(for transaction: ZcashTransaction.Overview) -> Single<[TransactionRecipient], Never> {
+        executeAction() {
+            await self.synchronizer.getRecipients(for: transaction)
+        }
+    }
+
+    public func getRecipients(for transaction: ZcashTransaction.Sent) -> Single<[TransactionRecipient], Never> {
+        executeAction() {
+            await self.synchronizer.getRecipients(for: transaction)
+        }
+    }
+
+    public func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) -> Single<[ZcashTransaction.Overview], Error> {
+        executeThrowingAction() {
+            try await self.synchronizer.allConfirmedTransactions(from: transaction, limit: limit)
+        }
     }
 
     public func latestHeight() -> Single<BlockHeight, Error> {

--- a/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
+++ b/Sources/ZcashLightClientKit/Transaction/PersistentTransactionManager.swift
@@ -210,9 +210,8 @@ class PersistentTransactionManager: OutboundTransactionManager {
     }
     
     func handleReorg(at height: BlockHeight) throws {
-        guard let affectedTxs = try self.allPendingTransactions()?.filter({ $0.minedHeight >= height }) else {
-            return
-        }
+        let affectedTxs = try allPendingTransactions()
+            .filter({ $0.minedHeight >= height })
         
         try affectedTxs
             .map { transaction -> PendingTransactionEntity in
@@ -235,7 +234,7 @@ class PersistentTransactionManager: OutboundTransactionManager {
         return true
     }
     
-    func allPendingTransactions() throws -> [PendingTransactionEntity]? {
+    func allPendingTransactions() throws -> [PendingTransactionEntity] {
         try repository.getAll()
     }
     

--- a/Sources/ZcashLightClientKit/Transaction/TransactionManager.swift
+++ b/Sources/ZcashLightClientKit/Transaction/TransactionManager.swift
@@ -45,11 +45,11 @@ protocol OutboundTransactionManager {
     Attempts to Cancel a transaction. Returns true if successful
     */
     func cancel(pendingTransaction: PendingTransactionEntity) -> Bool
-    
-    func allPendingTransactions() throws -> [PendingTransactionEntity]?
-    
+
+    func allPendingTransactions() throws -> [PendingTransactionEntity]
+
     func handleReorg(at blockHeight: BlockHeight) throws
-    
+
     /**
     Deletes a pending transaction from the database
     */

--- a/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
@@ -68,7 +68,7 @@ class WalletTransactionEncoder: TransactionEncoder {
 
         do {
             logger.debug("transaction id: \(txId)")
-            return try repository.find(id: txId)
+            return try await repository.find(id: txId)
         } catch {
             throw TransactionEncoderError.notFound(transactionId: txId)
         }
@@ -118,7 +118,7 @@ class WalletTransactionEncoder: TransactionEncoder {
         
         do {
             logger.debug("transaction id: \(txId)")
-            return try repository.find(id: txId)
+            return try await repository.find(id: txId)
         } catch {
             throw TransactionEncoderError.notFound(transactionId: txId)
         }

--- a/Tests/DarksideTests/BalanceTests.swift
+++ b/Tests/DarksideTests/BalanceTests.swift
@@ -801,8 +801,9 @@ class BalanceTests: XCTestCase {
         )
         
         wait(for: [syncedExpectation], timeout: 5)
-        
-        XCTAssertEqual(coordinator.synchronizer.clearedTransactions.count, 2)
+
+        let clearedTransactions = await coordinator.synchronizer.clearedTransactions
+        XCTAssertEqual(clearedTransactions.count, 2)
         XCTAssertEqual(coordinator.synchronizer.initializer.getBalance(), Zatoshi(200000))
     }
     
@@ -904,7 +905,7 @@ class BalanceTests: XCTestCase {
                 completion: { synchronizer in
                     let confirmedTx: ZcashTransaction.Overview!
                     do {
-                        confirmedTx = try synchronizer.allClearedTransactions().first(where: { confirmed -> Bool in
+                        confirmedTx = try await synchronizer.allClearedTransactions().first(where: { confirmed -> Bool in
                             confirmed.rawID == pendingTx?.rawTransactionId
                         })
                     } catch {
@@ -1104,7 +1105,8 @@ class BalanceTests: XCTestCase {
         there no sent transaction displayed
         */
 
-        XCTAssertNil( try coordinator.synchronizer.allSentTransactions().first(where: { $0.id == id }))
+        let sentTransactions = try await coordinator.synchronizer.allSentTransactions()
+        XCTAssertNil(sentTransactions.first(where: { $0.id == id }))
         /*
         There’s a pending transaction that has expired
         */

--- a/Tests/DarksideTests/ShieldFundsTests.swift
+++ b/Tests/DarksideTests/ShieldFundsTests.swift
@@ -319,7 +319,7 @@ class ShieldFundsTests: XCTestCase {
         guard shouldContinue else { return }
 
         // verify that there's a confirmed transaction that's the shielding transaction
-        let clearedTransaction = coordinator.synchronizer.clearedTransactions.first(
+        let clearedTransaction = await coordinator.synchronizer.clearedTransactions.first(
             where: { $0.rawID == shieldingPendingTx?.rawTransactionId }
         )
 

--- a/Tests/DarksideTests/SychronizerDarksideTests.swift
+++ b/Tests/DarksideTests/SychronizerDarksideTests.swift
@@ -269,7 +269,7 @@ class SychronizerDarksideTests: XCTestCase {
         XCTAssertEqual(states, expectedStates)
     }
 
-    @MainActor func testSyncAfterWipeWorks() async throws {
+    func testSyncAfterWipeWorks() async throws {
         try FakeChainBuilder.buildChain(darksideWallet: self.coordinator.service, branchID: branchID, chainName: chainName)
         let receivedTxHeight: BlockHeight = 663188
 

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -105,7 +105,7 @@ final class SynchronizerTests: XCTestCase {
 
     // MARK: Wipe tests
 
-    @MainActor func testWipeCalledWhichSyncDoesntRun() async throws {
+    func testWipeCalledWhichSyncDoesntRun() async throws {
         /*
          create fake chain
          */
@@ -161,7 +161,7 @@ final class SynchronizerTests: XCTestCase {
         await checkThatWipeWorked()
     }
 
-    @MainActor func testWipeCalledWhileSyncRuns() async throws {
+    func testWipeCalledWhileSyncRuns() async throws {
         /*
          1. create fake chain
          */
@@ -259,7 +259,7 @@ final class SynchronizerTests: XCTestCase {
 
     // MARK: Rewind tests
 
-    @MainActor func testRewindCalledWhileSyncRuns() async throws {
+    func testRewindCalledWhileSyncRuns() async throws {
         // 1 sync and get spendable funds
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName)
 
@@ -334,7 +334,8 @@ final class SynchronizerTests: XCTestCase {
         wait(for: [rewindExpectation], timeout: 5)
 
         // assert that after the new height is
-        XCTAssertEqual(try coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight(), self.birthday)
+        let lastScannedHeight = try await coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight()
+        XCTAssertEqual(lastScannedHeight, self.birthday)
 
         // check that the balance is cleared
         XCTAssertEqual(initialVerifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())

--- a/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
@@ -356,36 +356,70 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return true
         }
 
-        let result = synchronizer.cancelSpend(transaction: data.pendingTransactionEntity)
-        XCTAssertTrue(result)
+        let expectation = XCTestExpectation()
+
+        synchronizer.cancelSpend(transaction: data.pendingTransactionEntity) { result in
+            XCTAssertTrue(result)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testPendingTransactionsSucceed() {
         synchronizerMock.underlyingPendingTransactions = [data.pendingTransactionEntity]
-        let transactions = synchronizer.pendingTransactions
-        XCTAssertEqual(transactions.count, 1)
-        XCTAssertEqual(transactions[0].recipient, self.data.pendingTransactionEntity.recipient)
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.pendingTransactions() { transactions in
+            XCTAssertEqual(transactions.count, 1)
+            XCTAssertEqual(transactions[0].recipient, self.data.pendingTransactionEntity.recipient)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testClearedTransactionsSucceed() {
         synchronizerMock.underlyingClearedTransactions = [data.clearedTransaction]
-        let transactions = synchronizer.clearedTransactions
-        XCTAssertEqual(transactions.count, 1)
-        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.clearedTransactions() { transactions in
+            XCTAssertEqual(transactions.count, 1)
+            XCTAssertEqual(transactions[0].id, self.data.clearedTransaction.id)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testSentTransactionsSucceed() {
         synchronizerMock.underlyingSentTransactions = [data.sentTransaction]
-        let transactions = synchronizer.sentTransactions
-        XCTAssertEqual(transactions.count, 1)
-        XCTAssertEqual(transactions[0].id, data.sentTransaction.id)
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.sentTranscations() { transactions in
+            XCTAssertEqual(transactions.count, 1)
+            XCTAssertEqual(transactions[0].id, self.data.sentTransaction.id)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testReceivedTransactionsSucceed() {
         synchronizerMock.underlyingReceivedTransactions = [data.receivedTransaction]
-        let transactions = synchronizer.receivedTransactions
-        XCTAssertEqual(transactions.count, 1)
-        XCTAssertEqual(transactions[0].id, data.receivedTransaction.id)
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.receivedTransactions() { transactions in
+            XCTAssertEqual(transactions.count, 1)
+            XCTAssertEqual(transactions[0].id, self.data.receivedTransaction.id)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForClearedTransactionSucceed() throws {
@@ -396,10 +430,20 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [memo]
         }
 
-        let memos = try synchronizer.getMemos(for: data.clearedTransaction)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(memos.count, 1)
-        XCTAssertEqual(memos[0], memo)
+        synchronizer.getMemos(for: data.clearedTransaction) { result in
+            switch result {
+            case let .success(memos):
+                XCTAssertEqual(memos.count, 1)
+                XCTAssertEqual(memos[0], memo)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForClearedTransactionThrowsError() {
@@ -407,10 +451,18 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             throw "Some error"
         }
 
-        do {
-            _ = try synchronizer.getMemos(for: data.clearedTransaction)
-            XCTFail("Failure is expected")
-        } catch { }
+        let expectation = XCTestExpectation()
+
+        synchronizer.getMemos(for: data.clearedTransaction) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForReceivedTransactionSucceed() throws {
@@ -421,10 +473,20 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [memo]
         }
 
-        let memos = try synchronizer.getMemos(for: data.receivedTransaction)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(memos.count, 1)
-        XCTAssertEqual(memos[0], memo)
+        synchronizer.getMemos(for: data.receivedTransaction) { result in
+            switch result {
+            case let .success(memos):
+                XCTAssertEqual(memos.count, 1)
+                XCTAssertEqual(memos[0], memo)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForReceivedTransactionThrowsError() {
@@ -432,10 +494,18 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             throw "Some error"
         }
 
-        do {
-            _ = try synchronizer.getMemos(for: data.receivedTransaction)
-            XCTFail("Failure is expected")
-        } catch { }
+        let expectation = XCTestExpectation()
+
+        synchronizer.getMemos(for: data.receivedTransaction) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForSentTransactionSucceed() throws {
@@ -446,10 +516,20 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [memo]
         }
 
-        let memos = try synchronizer.getMemos(for: data.sentTransaction)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(memos.count, 1)
-        XCTAssertEqual(memos[0], memo)
+        synchronizer.getMemos(for: data.sentTransaction) { result in
+            switch result {
+            case let .success(memos):
+                XCTAssertEqual(memos.count, 1)
+                XCTAssertEqual(memos[0], memo)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetMemosForSentTransactionThrowsError() {
@@ -457,10 +537,18 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             throw "Some error"
         }
 
-        do {
-            _ = try synchronizer.getMemos(for: data.sentTransaction)
-            XCTFail("Failure is expected")
-        } catch { }
+        let expectation = XCTestExpectation()
+
+        synchronizer.getMemos(for: data.sentTransaction) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetRecipientsForClearedTransaction() {
@@ -471,10 +559,15 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [expectedRecipient]
         }
 
-        let recipients = synchronizer.getRecipients(for: data.clearedTransaction)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(recipients.count, 1)
-        XCTAssertEqual(recipients[0], expectedRecipient)
+        synchronizer.getRecipients(for: data.clearedTransaction) { recipients in
+            XCTAssertEqual(recipients.count, 1)
+            XCTAssertEqual(recipients[0], expectedRecipient)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetRecipientsForSentTransaction() {
@@ -485,10 +578,15 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [expectedRecipient]
         }
 
-        let recipients = synchronizer.getRecipients(for: data.sentTransaction)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(recipients.count, 1)
-        XCTAssertEqual(recipients[0], expectedRecipient)
+        synchronizer.getRecipients(for: data.sentTransaction) { recipients in
+            XCTAssertEqual(recipients.count, 1)
+            XCTAssertEqual(recipients[0], expectedRecipient)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testAllConfirmedTransactionsSucceed() throws {
@@ -498,10 +596,20 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return [self.data.clearedTransaction]
         }
 
-        let transactions = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
+        let expectation = XCTestExpectation()
 
-        XCTAssertEqual(transactions.count, 1)
-        XCTAssertEqual(transactions[0].id, data.clearedTransaction.id)
+        synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3) { result in
+            switch result {
+            case let .success(transactions):
+                XCTAssertEqual(transactions.count, 1)
+                XCTAssertEqual(transactions[0].id, self.data.clearedTransaction.id)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testAllConfirmedTransactionsThrowsError() throws {
@@ -509,10 +617,18 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             throw "Some error"
         }
 
-        do {
-            _ = try synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3)
-            XCTFail("Failure is expected")
-        } catch { }
+        let expectation = XCTestExpectation()
+
+        synchronizer.allConfirmedTransactions(from: data.clearedTransaction, limit: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testLatestHeightSucceed() {

--- a/Tests/OfflineTests/PagedTransactionRepositoryTests.swift
+++ b/Tests/OfflineTests/PagedTransactionRepositoryTests.swift
@@ -31,13 +31,13 @@ class PagedTransactionRepositoryTests: XCTestCase {
         transactionRepository = nil
     }
 
-    func testBrowsePages() {
+    func testBrowsePages() async {
         let pageSize = pagedTransactionRepository.pageSize
-        let pageCount = pagedTransactionRepository.pageCount
-        let totalItems = pagedTransactionRepository.itemCount
+        let pageCount = await pagedTransactionRepository.pageCount
+        let totalItems = await pagedTransactionRepository.itemCount
 
         for index in 0 ..< pageCount / pageSize {
-            guard let page = try? pagedTransactionRepository.page(index) else {
+            guard let page = try? await pagedTransactionRepository.page(index) else {
                 XCTFail("page failed to get page \(index)")
                 return
             }

--- a/Tests/OfflineTests/TransactionRepositoryTests.swift
+++ b/Tests/OfflineTests/TransactionRepositoryTests.swift
@@ -23,40 +23,30 @@ class TransactionRepositoryTests: XCTestCase {
         transactionRepository = nil
     }
     
-    func testCount() {
-        var count: Int?
-        XCTAssertNoThrow(try { count = try self.transactionRepository.countAll() }())
+    func testCount() async throws {
+        let count = try await self.transactionRepository.countAll()
         XCTAssertNotNil(count)
         XCTAssertEqual(count, 21)
     }
     
-    func testCountUnmined() {
-        var count: Int?
-        XCTAssertNoThrow(try { count = try self.transactionRepository.countUnmined() }())
+    func testCountUnmined() async throws {
+        let count = try await self.transactionRepository.countUnmined()
         XCTAssertNotNil(count)
         XCTAssertEqual(count, 0)
     }
 
-    func testBlockForHeight() {
-        var block: Block!
-        XCTAssertNoThrow(try { block = try self.transactionRepository.blockForHeight(663150) }())
-        XCTAssertEqual(block.height, 663150)
+    func testBlockForHeight() async throws {
+        let block = try await self.transactionRepository.blockForHeight(663150)
+        XCTAssertEqual(block?.height, 663150)
     }
 
-    func testLastScannedHeight() {
-        var height: BlockHeight!
-        XCTAssertNoThrow(try { height = try self.transactionRepository.lastScannedHeight() }())
+    func testLastScannedHeight() async throws {
+        let height = try await self.transactionRepository.lastScannedHeight()
         XCTAssertEqual(height, 665000)
     }
 
-    func testFindInRange() {
-        var transactions: [ZcashTransaction.Overview]!
-        XCTAssertNoThrow(
-            try {
-                transactions = try self.transactionRepository.find(in: 663218...663974, limit: 3, kind: .received)
-            }()
-        )
-
+    func testFindInRange() async throws {
+        let transactions = try await self.transactionRepository.find(in: 663218...663974, limit: 3, kind: .received)
         XCTAssertEqual(transactions.count, 3)
         XCTAssertEqual(transactions[0].minedHeight, 663974)
         XCTAssertEqual(transactions[0].isSentTransaction, false)
@@ -66,68 +56,55 @@ class TransactionRepositoryTests: XCTestCase {
         XCTAssertEqual(transactions[2].isSentTransaction, false)
     }
     
-    func testFindById() {
-        var transaction: ZcashTransaction.Overview!
-        XCTAssertNoThrow(try { transaction = try self.transactionRepository.find(id: 10) }())
-
+    func testFindById() async throws {
+        let transaction = try await self.transactionRepository.find(id: 10)
         XCTAssertEqual(transaction.id, 10)
         XCTAssertEqual(transaction.minedHeight, 663942)
         XCTAssertEqual(transaction.index, 5)
     }
     
-    func testFindByTxId() {
-        var transaction: ZcashTransaction.Overview!
-
+    func testFindByTxId() async throws {
         let id = Data(fromHexEncodedString: "01af48bcc4e9667849a073b8b5c539a0fc19de71aac775377929dc6567a36eff")!
-        
-        XCTAssertNoThrow(try { transaction = try self.transactionRepository.find(rawID: id) }())
-
+        let transaction = try await self.transactionRepository.find(rawID: id)
         XCTAssertEqual(transaction.id, 8)
         XCTAssertEqual(transaction.minedHeight, 663922)
         XCTAssertEqual(transaction.index, 1)
     }
     
-    func testFindAllSentTransactions() {
-        var transactions: [ZcashTransaction.Overview] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.find(offset: 0, limit: Int.max, kind: .sent) }())
+    func testFindAllSentTransactions() async throws {
+        let transactions = try await self.transactionRepository.find(offset: 0, limit: Int.max, kind: .sent)
         XCTAssertEqual(transactions.count, 13)
         transactions.forEach { XCTAssertEqual($0.isSentTransaction, true) }
     }
     
-    func testFindAllReceivedTransactions() {
-        var transactions: [ZcashTransaction.Overview] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.find(offset: 0, limit: Int.max, kind: .received) }())
+    func testFindAllReceivedTransactions() async throws {
+        let transactions = try await self.transactionRepository.find(offset: 0, limit: Int.max, kind: .received)
         XCTAssertEqual(transactions.count, 8)
         transactions.forEach { XCTAssertEqual($0.isSentTransaction, false) }
     }
     
-    func testFindAllTransactions() {
-        var transactions: [ZcashTransaction.Overview] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.find(offset: 0, limit: Int.max, kind: .all) }())
+    func testFindAllTransactions() async throws {
+        let transactions = try await self.transactionRepository.find(offset: 0, limit: Int.max, kind: .all)
         XCTAssertEqual(transactions.count, 21)
     }
 
-    func testFindReceivedOffsetLimit() {
-        var transactions: [ZcashTransaction.Received] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.findReceived(offset: 3, limit: 3) }())
-
+    func testFindReceivedOffsetLimit() async throws {
+        let transactions = try await self.transactionRepository.findReceived(offset: 3, limit: 3)
         XCTAssertEqual(transactions.count, 3)
         XCTAssertEqual(transactions[0].minedHeight, 664022)
         XCTAssertEqual(transactions[1].minedHeight, 664012)
         XCTAssertEqual(transactions[2].minedHeight, 664003)
     }
 
-    func testFindSentOffsetLimit() {
-        var transactions: [ZcashTransaction.Sent] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.findSent(offset: 3, limit: 3) }())
-
+    func testFindSentOffsetLimit() async throws {
+        let transactions = try await self.transactionRepository.findSent(offset: 3, limit: 3)
         XCTAssertEqual(transactions.count, 3)
         XCTAssertEqual(transactions[0].minedHeight, 664022)
         XCTAssertEqual(transactions[1].minedHeight, 664012)
         XCTAssertEqual(transactions[2].minedHeight, 663956)
     }
 
-    func testFindMemoForTransaction() {
+    func testFindMemoForTransaction() async throws {
         let transaction = ZcashTransaction.Overview(
             blockTime: nil,
             expiryHeight: nil,
@@ -145,14 +122,12 @@ class TransactionRepositoryTests: XCTestCase {
             value: Zatoshi.zero
         )
 
-        var memos: [Memo]!
-        XCTAssertNoThrow(try { memos = try self.transactionRepository.findMemos(for: transaction) }())
-
+        let memos = try await self.transactionRepository.findMemos(for: transaction)
         XCTAssertEqual(memos.count, 1)
         XCTAssertEqual(memos[0].toString(), "Some funds")
     }
 
-    func testFindMemoForReceivedTransaction() {
+    func testFindMemoForReceivedTransaction() async throws {
         let transaction = ZcashTransaction.Received(
             blockTime: 1,
             expiryHeight: nil,
@@ -167,14 +142,12 @@ class TransactionRepositoryTests: XCTestCase {
             value: Zatoshi.zero
         )
 
-        var memos: [Memo]!
-        XCTAssertNoThrow(try { memos = try self.transactionRepository.findMemos(for: transaction) }())
-
+        let memos = try await self.transactionRepository.findMemos(for: transaction)
         XCTAssertEqual(memos.count, 1)
         XCTAssertEqual(memos[0].toString(), "Some funds")
     }
 
-    func testFindMemoForSentTransaction() {
+    func testFindMemoForSentTransaction() async throws {
         let transaction = ZcashTransaction.Sent(
             blockTime: 1,
             expiryHeight: nil,
@@ -189,16 +162,13 @@ class TransactionRepositoryTests: XCTestCase {
             value: Zatoshi.zero
         )
 
-        var memos: [Memo]!
-        XCTAssertNoThrow(try { memos = try self.transactionRepository.findMemos(for: transaction) }())
-
+        let memos = try await self.transactionRepository.findMemos(for: transaction)
         XCTAssertEqual(memos.count, 1)
         XCTAssertEqual(memos[0].toString(), "Some funds")
     }
 
-    func testFindTransactionWithNULLMinedHeight() {
-        var transactions: [ZcashTransaction.Overview] = []
-        XCTAssertNoThrow(try { transactions = try self.transactionRepository.find(offset: 0, limit: 3, kind: .all) }())
+    func testFindTransactionWithNULLMinedHeight() async throws {
+        let transactions = try await self.transactionRepository.find(offset: 0, limit: 3, kind: .all)
 
         XCTAssertEqual(transactions.count, 3)
         XCTAssertEqual(transactions[0].id, 21)
@@ -212,21 +182,23 @@ class TransactionRepositoryTests: XCTestCase {
     func testFindAllPerformance() {
         // This is an example of a performance test case.
         self.measure {
-            // Put the code you want to measure the time of here.
-            do {
-                _ = try self.transactionRepository.find(offset: 0, limit: Int.max, kind: .all)
-            } catch {
-                XCTFail("find all failed")
+            let expectation = expectation(description: "Measure")
+            Task(priority: .userInitiated) {
+                // Put the code you want to measure the time of here.
+                do {
+                    _ = try await self.transactionRepository.find(offset: 0, limit: Int.max, kind: .all)
+                    expectation.fulfill()
+                } catch {
+                    XCTFail("find all failed")
+                }
             }
+            wait(for: [expectation], timeout: 2)
         }
     }
     
-    func testFindAllFrom() throws {
-        var transaction: ZcashTransaction.Overview!
-        XCTAssertNoThrow(try { transaction = try self.transactionRepository.find(id: 16) }())
-
-        var transactionsFrom: [ZcashTransaction.Overview] = []
-        XCTAssertNoThrow(try { transactionsFrom = try self.transactionRepository.find(from: transaction, limit: Int.max, kind: .all) }())
+    func testFindAllFrom() async throws {
+        let transaction = try await self.transactionRepository.find(id: 16)
+        let transactionsFrom = try await self.transactionRepository.find(from: transaction, limit: Int.max, kind: .all)
 
         XCTAssertEqual(transactionsFrom.count, 8)
 

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -40,7 +40,6 @@ class SynchronizerTests: XCTestCase {
         sdkSynchronizerSyncStatusHandler = nil
     }
 
-    @MainActor
     func testHundredBlocksSync() async throws {
         let derivationTool = DerivationTool(networkType: .mainnet)
         guard let seedData = Data(base64Encoded: "9VDVOZZZOWWHpZtq1Ebridp3Qeux5C+HwiRR0g7Oi7HgnMs8Gfln83+/Q1NnvClcaSwM4ADFL1uZHxypEWlWXg==") else {

--- a/Tests/TestUtils/SynchronizerMock.swift
+++ b/Tests/TestUtils/SynchronizerMock.swift
@@ -77,56 +77,64 @@ class SynchronizerMock: Synchronizer {
         return try await shieldFundsSpendingKeyMemoShieldingThresholdClosure(spendingKey, memo, shieldingThreshold)
     }
 
-    var cancelSpendTransactionClosure: ((PendingTransactionEntity) -> Bool)! = nil
-    func cancelSpend(transaction: PendingTransactionEntity) -> Bool {
-        return cancelSpendTransactionClosure(transaction)
+    var cancelSpendTransactionClosure: ((PendingTransactionEntity) async -> Bool)! = nil
+    func cancelSpend(transaction: PendingTransactionEntity) async -> Bool {
+        return await cancelSpendTransactionClosure(transaction)
     }
 
     var underlyingPendingTransactions: [PendingTransactionEntity]! = nil
-    var pendingTransactions: [PendingTransactionEntity] { underlyingPendingTransactions }
+    var pendingTransactions: [PendingTransactionEntity] {
+        get async { underlyingPendingTransactions }
+    }
 
     var underlyingClearedTransactions: [ZcashTransaction.Overview]! = nil
-    var clearedTransactions: [ZcashTransaction.Overview] { underlyingClearedTransactions }
+    var clearedTransactions: [ZcashTransaction.Overview] {
+        get async { underlyingClearedTransactions }
+    }
 
     var underlyingSentTransactions: [ZcashTransaction.Sent]! = nil
-    var sentTransactions: [ZcashTransaction.Sent] { underlyingSentTransactions }
+    var sentTransactions: [ZcashTransaction.Sent] {
+        get async { underlyingSentTransactions }
+    }
 
     var underlyingReceivedTransactions: [ZcashTransaction.Received]! = nil
-    var receivedTransactions: [ZcashTransaction.Received] { underlyingReceivedTransactions }
+    var receivedTransactions: [ZcashTransaction.Received] {
+        get async { underlyingReceivedTransactions }
+    }
 
     var paginatedTransactionsOfKindClosure: ((TransactionKind) -> PaginatedTransactionRepository)! = nil
     func paginatedTransactions(of kind: TransactionKind) -> PaginatedTransactionRepository {
         return paginatedTransactionsOfKindClosure(kind)
     }
 
-    var getMemosForTransactionClosure: ((ZcashTransaction.Overview) throws -> [Memo])! = nil
-    func getMemos(for transaction: ZcashTransaction.Overview) throws -> [Memo] {
-        return try getMemosForTransactionClosure(transaction)
+    var getMemosForTransactionClosure: ((ZcashTransaction.Overview) async throws -> [Memo])! = nil
+    func getMemos(for transaction: ZcashTransaction.Overview) async throws -> [Memo] {
+        return try await getMemosForTransactionClosure(transaction)
     }
 
-    var getMemosForReceivedTransactionClosure: ((ZcashTransaction.Received) throws -> [Memo])! = nil
-    func getMemos(for receivedTransaction: ZcashTransaction.Received) throws -> [Memo] {
-        return try getMemosForReceivedTransactionClosure(receivedTransaction)
+    var getMemosForReceivedTransactionClosure: ((ZcashTransaction.Received) async throws -> [Memo])! = nil
+    func getMemos(for receivedTransaction: ZcashTransaction.Received) async throws -> [Memo] {
+        return try await getMemosForReceivedTransactionClosure(receivedTransaction)
     }
 
-    var getMemosForSentTransactionClosure: ((ZcashTransaction.Sent) throws -> [Memo])! = nil
-    func getMemos(for sentTransaction: ZcashTransaction.Sent) throws -> [Memo] {
-        return try getMemosForSentTransactionClosure(sentTransaction)
+    var getMemosForSentTransactionClosure: ((ZcashTransaction.Sent) async throws -> [Memo])! = nil
+    func getMemos(for sentTransaction: ZcashTransaction.Sent) async throws -> [Memo] {
+        return try await getMemosForSentTransactionClosure(sentTransaction)
     }
 
-    var getRecipientsForClearedTransactionClosure: ((ZcashTransaction.Overview) -> [TransactionRecipient])! = nil
-    func getRecipients(for transaction: ZcashTransaction.Overview) -> [TransactionRecipient] {
-        return getRecipientsForClearedTransactionClosure(transaction)
+    var getRecipientsForClearedTransactionClosure: ((ZcashTransaction.Overview) async -> [TransactionRecipient])! = nil
+    func getRecipients(for transaction: ZcashTransaction.Overview) async -> [TransactionRecipient] {
+        return await getRecipientsForClearedTransactionClosure(transaction)
     }
 
-    var getRecipientsForSentTransactionClosure: ((ZcashTransaction.Sent) -> [TransactionRecipient])! = nil
-    func getRecipients(for transaction: ZcashTransaction.Sent) -> [TransactionRecipient] {
-        return getRecipientsForSentTransactionClosure(transaction)
+    var getRecipientsForSentTransactionClosure: ((ZcashTransaction.Sent) async -> [TransactionRecipient])! = nil
+    func getRecipients(for transaction: ZcashTransaction.Sent) async -> [TransactionRecipient] {
+        return await getRecipientsForSentTransactionClosure(transaction)
     }
 
-    var allConfirmedTransactionsFromTransactionClosure: ((ZcashTransaction.Overview, Int) throws -> [ZcashTransaction.Overview])! = nil
-    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) throws -> [ZcashTransaction.Overview] {
-        return try allConfirmedTransactionsFromTransactionClosure(transaction, limit)
+    var allConfirmedTransactionsFromTransactionClosure: ((ZcashTransaction.Overview, Int) async throws -> [ZcashTransaction.Overview])! = nil
+    func allConfirmedTransactions(from transaction: ZcashTransaction.Overview, limit: Int) async throws -> [ZcashTransaction.Overview] {
+        return try await allConfirmedTransactionsFromTransactionClosure(transaction, limit)
     }
 
     var latestHeightClosure: (() async throws -> BlockHeight)! = nil


### PR DESCRIPTION
Closes #484.

- `TransactionRepository` has async API. `Synchronizer` and alternative APIs are updated accordingly.

These methods and properties in the `Synchronizer` are async now:
- `cancelSpend(transaction:)`
- All the variants of the `getMemos(for:)` method.
- All the variants fo the `getRecipients(for:)` method.
- `allConfirmedTransactions(from:limit:)`
- `pendingTransactions`
- `clearedTransactions`
- `sentTransactions`
- `receivedTransactions`

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.