### PR TITLE
[#876] Add tests which runs multiple instances of the SDKSynchronizer

### DIFF
--- a/Example/ZcashLightClientSample/ZcashLightClientSample.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -90,6 +90,20 @@
                ReferencedContainer = "container:../..">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AliasDarksideTests"
+               BuildableName = "AliasDarksideTests"
+               BlueprintName = "AliasDarksideTests"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,13 @@ let package = Package(
             dependencies: ["ZcashLightClientKit", "TestUtils"]
         ),
         .testTarget(
+            name: "AliasDarksideTests",
+            dependencies: ["ZcashLightClientKit", "TestUtils"],
+            exclude: [
+                "scripts/"
+            ]
+        ),
+        .testTarget(
             name: "PerformanceTests",
             dependencies: ["ZcashLightClientKit", "TestUtils"]
         )

--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -192,7 +192,7 @@ public class Initializer {
             urls: updatedURLs,
             endpoint: endpoint,
             service: Self.makeLightWalletServiceFactory(endpoint: endpoint).make(),
-            repository: TransactionRepositoryBuilder.build(dataDbURL: dataDbURL),
+            repository: TransactionRepositoryBuilder.build(dataDbURL: updatedURLs.dataDbURL),
             accountRepository: AccountRepositoryBuilder.build(
                 dataDbURL: updatedURLs.dataDbURL,
                 readOnly: true,

--- a/Tests/AliasDarksideTests/SDKSynchronizerAliasDarksideTests.swift
+++ b/Tests/AliasDarksideTests/SDKSynchronizerAliasDarksideTests.swift
@@ -1,0 +1,109 @@
+//
+//  SDKSynchronizerAliasDarksideTests.swift
+//  
+//
+//  Created by Michal Fousek on 28.03.2023.
+//
+
+import Combine
+import Foundation
+@testable import TestUtils
+import XCTest
+@testable import ZcashLightClientKit
+
+/*
+ This test creates multiple instances of the `SDKSynchronizer` and then run sync on those in parallel. To achieve this it's required to run multiple
+ instances of the lightwalletd in darkside mode.
+
+ How to run this test:
+ 1. Have binary of lightwalletd which you want to use in directory which is in $PATH.
+ 2. Go to directory where this file is and then go there in `scripts/` directory.
+ 3. First check file `servers_config.zsh`. Aliases count should be same as aliases count defined in `aliases` variable. And starting port should be
+    same as `startingPort`.
+ 4. Use `run_darkside_servers.zsh` script to run all the servers. This script also creates rundir for each instance of the lightwalletd in the current
+    directory. You can find logs there.
+ 5. Run this test.
+ 6. When you are done use `kill_and_clean_servers.zsh` script to shutdown servers and clean all the data (pidfile, rundirs, logs).
+ */
+class SDKSynchronizerAliasDarksideTests: XCTestCase {
+    // Test creates instance of the `SDKSynchronizer` for each of these aliases.
+    let aliases: [ZcashSynchronizerAlias] = [.default, .custom("custom-1"), .custom("custom-2"), .custom("custom-3"), .custom("custom-4")]
+    // First instance of the `SDKSynchronizer` uses this port. Second one uses startPort + 1, thirs one uses startPort + 2 and so on.
+    let startingPort = 9167
+    // How many blocks to sync in each instance of the `SDKSynchronizer`.
+    let syncLength = 2000
+    var coordinators: [TestCoordinator] = []
+    let branchID = "2bb40e60"
+    let chainName = "main"
+    let network = DarksideWalletDNetwork()
+    var birthday: BlockHeight = 663150
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        for (index, alias) in aliases.enumerated() {
+            let endpoint = LightWalletEndpoint(
+                address: Constants.address,
+                port: startingPort + index,
+                secure: false,
+                singleCallTimeoutInMillis: 10000,
+                streamingCallTimeoutInMillis: 1000000
+            )
+
+            let coordinator = try await TestCoordinator(
+                alias: alias,
+                walletBirthday: birthday,
+                network: network,
+                callPrepareInConstructor: true,
+                endpoint: endpoint
+            )
+
+            try coordinator.reset(saplingActivation: birthday, branchID: branchID, chainName: chainName)
+
+            coordinators.append(coordinator)
+        }
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        for coordinator in coordinators {
+            try await coordinator.stop()
+            try? FileManager.default.removeItem(at: coordinator.databases.fsCacheDbRoot)
+            try? FileManager.default.removeItem(at: coordinator.databases.dataDB)
+            try? FileManager.default.removeItem(at: coordinator.databases.pendingDB)
+        }
+        coordinators = []
+    }
+
+    func testMultipleSynchronizersCanRunAtOnce() async throws {
+        var expectations: [XCTestExpectation] = []
+
+        for coordinator in coordinators {
+            try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName, length: syncLength)
+            try coordinator.applyStaged(blockheight: birthday + syncLength)
+            sleep(2)
+        }
+
+        for coordinator in coordinators {
+            let expectation = XCTestExpectation(description: "Synchronizer \(coordinator.synchronizer.alias.description) expectation")
+            expectations.append(expectation)
+
+            try await coordinator.sync(
+                completion: { _ in
+                    expectation.fulfill()
+                },
+                error: self.handleError
+            )
+        }
+
+        wait(for: expectations, timeout: TimeInterval(aliases.count * 5))
+    }
+
+    func handleError(_ error: Error?) async {
+        guard let testError = error else {
+            XCTFail("failed with nil error")
+            return
+        }
+        XCTFail("Failed with error: \(testError)")
+    }
+}

--- a/Tests/AliasDarksideTests/scripts/kill_and_clean_servers.zsh
+++ b/Tests/AliasDarksideTests/scripts/kill_and_clean_servers.zsh
@@ -1,0 +1,13 @@
+#!/bin/zsh
+
+source servers_config.zsh
+
+for syncAlias in $syncAliases; do
+    rundir="rundir-${syncAlias}"
+    pidfile="/tmp/lightwalletd-${syncAlias}.pid"
+    pid=`cat ${pidfile}`
+
+    kill $pid
+    rm -rf $rundir
+    rm $pidfile
+done

--- a/Tests/AliasDarksideTests/scripts/run_darkside_servers.zsh
+++ b/Tests/AliasDarksideTests/scripts/run_darkside_servers.zsh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+
+source servers_config.zsh
+index=0
+
+for syncAlias in $syncAliases; do
+    port=$(($startPort+$index))
+    rundir="rundir-${syncAlias}"
+
+    mkdir $rundir
+    cd $rundir
+    lightwalletd --darkside-very-insecure --no-tls-very-insecure --data-dir ./ --grpc-bind-addr "127.0.0.1:${port}" --log-file "stdout.log" --log-level 10 &
+    cd ..
+
+    pid="$!"
+    echo $pid > "/tmp/lightwalletd-${syncAlias}.pid"
+
+    index=$(($index+1))
+done

--- a/Tests/AliasDarksideTests/scripts/servers_config.zsh
+++ b/Tests/AliasDarksideTests/scripts/servers_config.zsh
@@ -1,0 +1,4 @@
+#!/bin/zsh
+
+syncAliases=(default custom-1 custom-2 custom-3 custom-4)
+startPort=9167

--- a/Tests/DarksideTests/BlockDownloaderTests.swift
+++ b/Tests/DarksideTests/BlockDownloaderTests.swift
@@ -43,7 +43,7 @@ class BlockDownloaderTests: XCTestCase {
         try storage.create()
 
         downloader = BlockDownloaderServiceImpl(service: service, storage: storage)
-        darksideWalletService = DarksideWalletService(service: service as! LightWalletGRPCService)
+        darksideWalletService = DarksideWalletService(endpoint: LightWalletEndpointBuilder.default, service: service as! LightWalletGRPCService)
         
         try FakeChainBuilder.buildChain(darksideWallet: darksideWalletService, branchID: branchID, chainName: chainName)
         try darksideWalletService.applyStaged(nextLatestHeight: 663250)

--- a/Tests/TestUtils/DarkSideWalletService.swift
+++ b/Tests/TestUtils/DarkSideWalletService.swift
@@ -47,13 +47,13 @@ class DarksideWalletService: LightWalletService {
     var darksideService: DarksideStreamerClient
 
     init(endpoint: LightWalletEndpoint) {
-        self.channel = ChannelProvider().channel()
+        self.channel = ChannelProvider().channel(endpoint: endpoint)
         self.service = LightWalletServiceFactory(endpoint: endpoint).make()
         self.darksideService = DarksideStreamerClient(channel: channel)
     }
 
-    init(service: LightWalletService) {
-        self.channel = ChannelProvider().channel()
+    init(endpoint: LightWalletEndpoint, service: LightWalletService) {
+        self.channel = ChannelProvider().channel(endpoint: endpoint)
         self.darksideService = DarksideStreamerClient(channel: channel)
         self.service = service
     }

--- a/Tests/TestUtils/Tests+Utils.swift
+++ b/Tests/TestUtils/Tests+Utils.swift
@@ -49,9 +49,7 @@ enum LightWalletEndpointBuilder {
 }
 
 class ChannelProvider {
-    func channel(secure: Bool = false) -> GRPCChannel {
-        let endpoint = LightWalletEndpointBuilder.default
-
+    func channel(endpoint: LightWalletEndpoint = LightWalletEndpointBuilder.default, secure: Bool = false) -> GRPCChannel {
         let connectionBuilder = secure ?
         ClientConnection.usingPlatformAppropriateTLS(for: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default)) :
         ClientConnection.insecure(group: NIOTSEventLoopGroup(loopCount: 1, defaultQoS: .default))


### PR DESCRIPTION
Closes #876.

- Add `testMultipleSynchronizersCanRunAtOnce()` test which creates multiple instances of the `SDKSynchronizer` and then executes sync in paralell.
- To achieve this it's required to have multiple instances of the lightwalletd in the darkside mode. Because of this new test is in the new target `AliasDarksideTests`. It's little bit harder to run this test than to run regular darkside tests. So it has it's own target.
- Fix bug when all the instances of the `SDKSynchronizer` used same data DB even with different aliases.
- Add script to run multiple instances of the lightwalletd in darkside mode. And add script to stop these instances and clean after those.
- Update `DarksideWalletService` a little so the endpoint can be passed to it. Without this it would always use default endpoint when created with service.
- Small cleanup in `TestCoordinator`.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.