### PR TITLE
[#469] Make ZcashRustBackendWelding async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# unreleased
+### [#469] ZcashRustBackendWelding to Async
+
+This is mostly internal change. But it also touches the public API.
+
+These methods previously returned Optional and now those methods return non-optional value and those methods can an throw error:
+- `getSaplingAddress(accountIndex: Int) async throws -> SaplingAddress`
+- `func getUnifiedAddress(accountIndex: Int) async throws -> UnifiedAddress`
+- `func getTransparentAddress(accountIndex: Int) async throws -> TransparentAddress`
+
+These methods are now async:
+- `func getShieldedBalance(accountIndex: Int) async throws -> Zatoshi`
+- `func getShieldedVerifiedBalance(accountIndex: Int) async throws -> Zatoshi`
+
+`Initializer` no longer have methods to get balance. Use `SDKSynchronizer` (or it's alternative APIs) to get balance.
+
+
 # 0.20.0-beta
 
 ### New Checkpoints:

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Get Address/GetAddressViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Get Address/GetAddressViewController.swift
@@ -19,7 +19,7 @@ class GetAddressViewController: UIViewController {
         let synchronizer = SDKSynchronizer.shared
 
         Task { @MainActor in
-            guard let uAddress = await synchronizer.getUnifiedAddress(accountIndex: 0) else {
+            guard let uAddress = try? await synchronizer.getUnifiedAddress(accountIndex: 0) else {
                 unifiedAddressLabel.text = "could not derive UA"
                 tAddressLabel.text = "could not derive tAddress"
                 saplingAddress.text = "could not derive zAddress"
@@ -29,8 +29,8 @@ class GetAddressViewController: UIViewController {
             // you can either try to extract receivers from the UA itself or request the Synchronizer to do it for you. Certain UAs might not contain all the receivers you expect.
             unifiedAddressLabel.text = uAddress.stringEncoded
 
-            tAddressLabel.text = uAddress.transparentReceiver()?.stringEncoded ?? "could not extract transparent receiver from UA"
-            saplingAddress.text = uAddress.saplingReceiver()?.stringEncoded ?? "could not extract sapling receiver from UA"
+            tAddressLabel.text = (try? uAddress.transparentReceiver())?.stringEncoded ?? "could not extract transparent receiver from UA"
+            saplingAddress.text = (try? uAddress.saplingReceiver())?.stringEncoded ?? "could not extract sapling receiver from UA"
 
             unifiedAddressLabel.addGestureRecognizer(
                 UITapGestureRecognizer(

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Get Balance/GetBalanceViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Get Balance/GetBalanceViewController.swift
@@ -15,9 +15,13 @@ class GetBalanceViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let synchronizer = AppDelegate.shared.sharedSynchronizer
         self.title = "Account 0 Balance"
-        self.balance.text = "\(Initializer.shared.getBalance().formattedString ?? "0.0") ZEC"
-        self.verified.text = "\(Initializer.shared.getVerifiedBalance().formattedString ?? "0.0") ZEC"
+
+        Task { @MainActor in
+            self.balance.text = "\(try? await synchronizer.getShieldedBalance().formattedString ?? "0.0") ZEC"
+            self.verified.text = "\(try? await synchronizer.getShieldedVerifiedBalance().formattedString ?? "0.0") ZEC"
+        }
     }
 }
 

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Get UTXOs/GetUTXOsViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Get UTXOs/GetUTXOsViewController.swift
@@ -26,7 +26,7 @@ class GetUTXOsViewController: UIViewController {
         let synchronizer = SDKSynchronizer.shared
 
         Task { @MainActor in
-            let tAddress = await synchronizer.getTransparentAddress(accountIndex: 0)?.stringEncoded ?? "no t-address found"
+            let tAddress = (try? await synchronizer.getTransparentAddress(accountIndex: 0))?.stringEncoded ?? "no t-address found"
 
             self.transparentAddressLabel.text = tAddress
             

--- a/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
+++ b/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
@@ -41,7 +41,7 @@ struct BlockEnhancerImpl {
         let block = String(describing: transaction.minedHeight)
         logger.debug("Decrypting and storing transaction id: \(transactionID) block: \(block)")
 
-        let decryptionResult = rustBackend.decryptAndStoreTransaction(
+        let decryptionResult = await rustBackend.decryptAndStoreTransaction(
             dbData: config.dataDb,
             txBytes: fetchedTransaction.raw.bytes,
             minedHeight: Int32(fetchedTransaction.minedHeight),

--- a/Sources/ZcashLightClientKit/Block/SaplingParameters/SaplingParametersHandler.swift
+++ b/Sources/ZcashLightClientKit/Block/SaplingParameters/SaplingParametersHandler.swift
@@ -30,12 +30,12 @@ extension SaplingParametersHandlerImpl: SaplingParametersHandler {
         try Task.checkCancellation()
 
         do {
-            let totalShieldedBalance = try rustBackend.getBalance(
+            let totalShieldedBalance = try await rustBackend.getBalance(
                 dbData: config.dataDb,
                 account: Int32(0),
                 networkType: config.networkType
             )
-            let totalTransparentBalance = try rustBackend.getTransparentBalance(
+            let totalTransparentBalance = try await rustBackend.getTransparentBalance(
                 dbData: config.dataDb,
                 account: Int32(0),
                 networkType: config.networkType

--- a/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
+++ b/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
@@ -45,7 +45,7 @@ extension BlockScannerImpl: BlockScanner {
             let batchSize = scanBatchSize(startScanHeight: previousScannedHeight + 1, network: self.config.networkType)
 
             let scanStartTime = Date()
-            guard self.rustBackend.scanBlocks(
+            guard await self.rustBackend.scanBlocks(
                 fsBlockDbRoot: config.fsBlockCacheRoot,
                 dbData: config.dataDB,
                 limit: batchSize,

--- a/Sources/ZcashLightClientKit/Block/Validate/BlockValidator.swift
+++ b/Sources/ZcashLightClientKit/Block/Validate/BlockValidator.swift
@@ -37,7 +37,7 @@ extension BlockValidatorImpl: BlockValidator {
         try Task.checkCancellation()
 
         let startTime = Date()
-        let result = rustBackend.validateCombinedChain(
+        let result = await rustBackend.validateCombinedChain(
             fsBlockDbRoot: config.fsBlockCacheRoot,
             dbData: config.dataDB,
             networkType: config.networkType,

--- a/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/ClosureSynchronizer.swift
@@ -32,9 +32,9 @@ public protocol ClosureSynchronizer {
     func start(retry: Bool, completion: @escaping (Error?) -> Void)
     func stop(completion: @escaping () -> Void)
 
-    func getSaplingAddress(accountIndex: Int, completion: @escaping (SaplingAddress?) -> Void)
-    func getUnifiedAddress(accountIndex: Int, completion: @escaping (UnifiedAddress?) -> Void)
-    func getTransparentAddress(accountIndex: Int, completion: @escaping (TransparentAddress?) -> Void)
+    func getSaplingAddress(accountIndex: Int, completion: @escaping (Result<SaplingAddress, Error>) -> Void)
+    func getUnifiedAddress(accountIndex: Int, completion: @escaping (Result<UnifiedAddress, Error>) -> Void)
+    func getTransparentAddress(accountIndex: Int, completion: @escaping (Result<TransparentAddress, Error>) -> Void)
 
     func sendToAddress(
         spendingKey: UnifiedSpendingKey,
@@ -79,9 +79,9 @@ public protocol ClosureSynchronizer {
 
     func getTransparentBalance(accountIndex: Int, completion: @escaping (Result<WalletBalance, Error>) -> Void)
 
-    func getShieldedBalance(accountIndex: Int) -> Zatoshi
+    func getShieldedBalance(accountIndex: Int, completion: @escaping (Result<Zatoshi, Error>) -> Void)
 
-    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi
+    func getShieldedVerifiedBalance(accountIndex: Int, completion: @escaping (Result<Zatoshi, Error>) -> Void)
 
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't

--- a/Sources/ZcashLightClientKit/CombineSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/CombineSynchronizer.swift
@@ -38,9 +38,9 @@ public protocol CombineSynchronizer {
     func start(retry: Bool) -> Completable<Error>
     func stop() -> Completable<Never>
 
-    func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress?, Never>
-    func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress?, Never>
-    func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress?, Never>
+    func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress, Error>
+    func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress, Error>
+    func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress, Error>
 
     func sendToAddress(
         spendingKey: UnifiedSpendingKey,
@@ -78,10 +78,8 @@ public protocol CombineSynchronizer {
     func refreshUTXOs(address: TransparentAddress, from height: BlockHeight) -> Single<RefreshedUTXOs, Error>
 
     func getTransparentBalance(accountIndex: Int) -> Single<WalletBalance, Error>
-
-    func getShieldedBalance(accountIndex: Int) -> Zatoshi
-
-    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi
+    func getShieldedBalance(accountIndex: Int) -> Single<Zatoshi, Error>
+    func getShieldedVerifiedBalance(accountIndex: Int) -> Single<Zatoshi, Error>
 
     func rewind(_ policy: RewindPolicy) -> Completable<Error>
     func wipe() -> Completable<Error>

--- a/Sources/ZcashLightClientKit/Repository/CompactBlockRepository.swift
+++ b/Sources/ZcashLightClientKit/Repository/CompactBlockRepository.swift
@@ -29,7 +29,7 @@ enum CompactBlockRepositoryError: Error, Equatable {
 
 protocol CompactBlockRepository {
     /// Creates the underlying repository
-    func create() throws
+    func create() async throws
 
     /**
     Gets the height of the highest block that is currently stored.

--- a/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
+++ b/Sources/ZcashLightClientKit/Rust/ZcashRustBackendWelding.swift
@@ -55,7 +55,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         seed: [UInt8],
         networkType: NetworkType
-    ) throws -> UnifiedSpendingKey
+    ) async throws -> UnifiedSpendingKey
 
     /// Creates a transaction to the given address from the given account
     /// - Parameter dbData: URL for the Data DB
@@ -76,7 +76,7 @@ protocol ZcashRustBackendWelding {
         spendParamsPath: String,
         outputParamsPath: String,
         networkType: NetworkType
-    ) -> Int64 // swiftlint:disable function_parameter_count
+    ) async -> Int64 // swiftlint:disable function_parameter_count
 
     /// Scans a transaction for any information that can be decrypted by the accounts in the
     /// wallet, and saves it to the wallet.
@@ -90,7 +90,7 @@ protocol ZcashRustBackendWelding {
         txBytes: [UInt8],
         minedHeight: Int32,
         networkType: NetworkType
-    ) -> Bool
+    ) async -> Bool
 
     /// Derives and returns a unified spending key from the given seed for the given account ID.
     /// Returns the binary encoding of the spending key. The caller should manage the memory of (and store, if necessary) the returned spending key in a secure fashion.
@@ -112,7 +112,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> Int64
+    ) async throws -> Int64
 
     /// Returns the most-recently-generated unified payment address for the specified account.
     /// - parameter dbData: location of the data db
@@ -122,7 +122,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> UnifiedAddress
+    ) async throws -> UnifiedAddress
 
     /// Wallets might need to be rewound because of a reorg, or by user request.
     /// There are times where the wallet could get out of sync for many reasons and
@@ -140,7 +140,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         height: Int32,
         networkType: NetworkType
-    ) -> Int32
+    ) async -> Int32
 
     /// Returns a newly-generated unified payment address for the specified account, with the next available diversifier.
     /// - parameter dbData: location of the data db
@@ -150,7 +150,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> UnifiedAddress
+    ) async throws -> UnifiedAddress
 
     /// get received memo from note
     /// - parameter dbData: location of the data db file
@@ -160,13 +160,13 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         idNote: Int64,
         networkType: NetworkType
-    ) -> Memo?
+    ) async -> Memo?
 
     /// Returns the Sapling receiver within the given Unified Address, if any.
     /// - Parameter uAddr: a `UnifiedAddress`
     /// - Returns a `SaplingAddress` if any
     /// - Throws `receiverNotFound` when the receiver is not found. `invalidUnifiedAddress` if the UA provided is not valid
-    static func getSaplingReceiver(for uAddr: UnifiedAddress) throws -> SaplingAddress?
+    static func getSaplingReceiver(for uAddr: UnifiedAddress) throws -> SaplingAddress
 
     /// get sent memo from note
     /// - parameter dbData: location of the data db file
@@ -177,7 +177,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         idNote: Int64,
         networkType: NetworkType
-    ) -> Memo?
+    ) async -> Memo?
 
     /// Get the verified cached transparent balance for the given address
     /// - parameter dbData: location of the data db file
@@ -187,13 +187,13 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> Int64
+    ) async throws -> Int64
 
     /// Returns the transparent receiver within the given Unified Address, if any.
     /// - parameter uAddr: a `UnifiedAddress`
     /// - Returns a `TransparentAddress` if any
     /// - Throws `receiverNotFound` when the receiver is not found. `invalidUnifiedAddress` if the UA provided is not valid
-    static func getTransparentReceiver(for uAddr: UnifiedAddress) throws -> TransparentAddress?
+    static func getTransparentReceiver(for uAddr: UnifiedAddress) throws -> TransparentAddress
 
     /// gets the latest error if available. Clear the existing error
     ///  - Returns a `RustWeldingError` if exists
@@ -212,7 +212,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         ufvks: [UnifiedFullViewingKey],
         networkType: NetworkType
-    ) throws
+    ) async throws
 
     /// initializes the data db. This will performs any migrations needed on the sqlite file
     /// provided. Some migrations might need that callers provide the seed bytes.
@@ -226,7 +226,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         seed: [UInt8]?,
         networkType: NetworkType
-    ) throws -> DbInitResult
+    ) async throws -> DbInitResult
 
     /// Returns the network and address type for the given Zcash address string,
     /// if the string represents a valid Zcash address.
@@ -288,7 +288,7 @@ protocol ZcashRustBackendWelding {
         time: UInt32,
         saplingTree: String,
         networkType: NetworkType
-    ) throws // swiftlint:disable function_parameter_count
+    ) async throws // swiftlint:disable function_parameter_count
 
     /// Returns a list of the transparent receivers for the diversified unified addresses that have
     /// been allocated for the provided account.
@@ -299,7 +299,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> [TransparentAddress]
+    ) async throws -> [TransparentAddress]
 
     /// get the verified balance from the given account
     /// - parameter dbData: location of the data db
@@ -309,7 +309,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> Int64
+    ) async throws -> Int64
 
     /// Get the verified cached transparent balance for the given account
     /// - parameter dbData: location of the data db
@@ -319,7 +319,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         account: Int32,
         networkType: NetworkType
-    ) throws -> Int64
+    ) async throws -> Int64
 
     /// Checks that the scanned blocks in the data database, when combined with the recent
     /// `CompactBlock`s in the cache database, form a valid chain.
@@ -344,7 +344,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         networkType: NetworkType,
         limit: UInt32
-    ) -> Int32
+    ) async -> Int32
 
     /// Resets the state of the database to only contain block and transaction information up to the given height. clears up all derived data as well
     /// - parameter dbData: `URL` pointing to the filesystem root directory where the fsBlock cache is.
@@ -355,7 +355,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         height: Int32,
         networkType: NetworkType
-    ) -> Bool
+    ) async -> Bool
 
     /// Resets the state of the FsBlock database to only contain block and transaction information up to the given height.
     /// - Note: this does not delete the files. Only rolls back the database.
@@ -365,7 +365,7 @@ protocol ZcashRustBackendWelding {
     static func rewindCacheToHeight(
         fsBlockDbRoot: URL,
         height: Int32
-    ) -> Bool
+    ) async -> Bool
 
     /// Scans new blocks added to the cache for any transactions received by the tracked
     /// accounts.
@@ -391,7 +391,7 @@ protocol ZcashRustBackendWelding {
         dbData: URL,
         limit: UInt32,
         networkType: NetworkType
-    ) -> Bool
+    ) async -> Bool
 
     /// Upserts a UTXO into the data db database
     /// - parameter dbData: location of the data db file
@@ -410,7 +410,7 @@ protocol ZcashRustBackendWelding {
         value: Int64,
         height: BlockHeight,
         networkType: NetworkType
-    ) throws -> Bool
+    ) async throws -> Bool
 
     /// Creates a transaction to shield all found UTXOs in data db for the account the provided `UnifiedSpendingKey` has spend authority for.
     /// - Parameter dbData: URL for the Data DB
@@ -427,7 +427,7 @@ protocol ZcashRustBackendWelding {
         spendParamsPath: String,
         outputParamsPath: String,
         networkType: NetworkType
-    ) -> Int64
+    ) async -> Int64
 
     /// Obtains the available receiver typecodes for the given String encoded Unified Address
     /// - Parameter address: public key represented as a String
@@ -459,7 +459,7 @@ protocol ZcashRustBackendWelding {
     /// format `{height}-{hash}-block`. This directory has must be granted both write and read permissions.
     /// - returns `true` when successful, `false` when fails but no throwing information was found
     /// - throws `RustWeldingError` when fails to initialize
-    static func initBlockMetadataDb(fsBlockDbRoot: URL) throws -> Bool
+    static func initBlockMetadataDb(fsBlockDbRoot: URL) async throws -> Bool
 
     /// Write compact block metadata to a database known to the Rust layer
     /// - Parameter fsBlockDbRoot: `URL` pointing to the filesystem root directory where the fsBlock cache is.
@@ -468,12 +468,12 @@ protocol ZcashRustBackendWelding {
     /// - Parameter blocks: The `ZcashCompactBlock`s that are going to be marked as stored by the
     /// metadata Db.
     /// - Returns `true` if the operation was successful, `false` otherwise.
-    static func writeBlocksMetadata(fsBlockDbRoot: URL, blocks: [ZcashCompactBlock]) throws -> Bool
+    static func writeBlocksMetadata(fsBlockDbRoot: URL, blocks: [ZcashCompactBlock]) async throws -> Bool
 
     /// Gets the latest block height stored in the filesystem based cache.
     /// -  Parameter fsBlockDbRoot: `URL` pointing to the filesystem root directory where the fsBlock cache is.
     /// this directory  is expected to contain a `/blocks` sub-directory with the blocks stored in the convened filename
     /// format `{height}-{hash}-block`. This directory has must be granted both write and read permissions.
     /// - Returns `BlockHeight` of the latest cached block or `.empty` if no blocks are stored.
-    static func latestCachedBlockHeight(fsBlockDbRoot: URL) -> BlockHeight
+    static func latestCachedBlockHeight(fsBlockDbRoot: URL) async -> BlockHeight
 }

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -156,17 +156,17 @@ public protocol Synchronizer: AnyObject {
     /// Gets the sapling shielded address for the given account.
     /// - Parameter accountIndex: the optional accountId whose address is of interest. By default, the first account is used.
     /// - Returns the address or nil if account index is incorrect
-    func getSaplingAddress(accountIndex: Int) async -> SaplingAddress?
+    func getSaplingAddress(accountIndex: Int) async throws -> SaplingAddress
 
     /// Gets the unified address for the given account.
     /// - Parameter accountIndex: the optional accountId whose address is of interest. By default, the first account is used.
     /// - Returns the address or nil if account index is incorrect
-    func getUnifiedAddress(accountIndex: Int) async -> UnifiedAddress?
+    func getUnifiedAddress(accountIndex: Int) async throws -> UnifiedAddress
 
     /// Gets the transparent address for the given account.
     /// - Parameter accountIndex: the optional accountId whose address is of interest. By default, the first account is used.
     /// - Returns the address or nil if account index is incorrect
-    func getTransparentAddress(accountIndex: Int) async -> TransparentAddress?
+    func getTransparentAddress(accountIndex: Int) async throws -> TransparentAddress
     
     /// Sends zatoshi.
     /// - Parameter spendingKey: the `UnifiedSpendingKey` that allows spends to occur.
@@ -258,11 +258,15 @@ public protocol Synchronizer: AnyObject {
     /// Returns the last stored transparent balance
     func getTransparentBalance(accountIndex: Int) async throws -> WalletBalance
 
-    /// Returns the shielded total balance (includes verified and unverified balance)
-    func getShieldedBalance(accountIndex: Int) -> Zatoshi
+    /// get (unverified) balance from the given account index
+    /// - Parameter accountIndex: the index of the account
+    /// - Returns: balance in `Zatoshi`
+    func getShieldedBalance(accountIndex: Int) async throws -> Zatoshi
 
-    /// Returns the shielded verified balance (anchor is 10 blocks back)
-    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi
+    /// get verified balance from the given account index
+    /// - Parameter accountIndex: the index of the account
+    /// - Returns: balance in `Zatoshi`
+    func getShieldedVerifiedBalance(accountIndex: Int) async throws -> Zatoshi
 
     /// Rescans the known blocks with the current keys.
     ///

--- a/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/ClosureSDKSynchronizer.swift
@@ -54,21 +54,21 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         }
     }
 
-    public func getSaplingAddress(accountIndex: Int, completion: @escaping (SaplingAddress?) -> Void) {
-        executeAction(completion) {
-            await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
+    public func getSaplingAddress(accountIndex: Int, completion: @escaping (Result<SaplingAddress, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
         }
     }
 
-    public func getUnifiedAddress(accountIndex: Int, completion: @escaping (UnifiedAddress?) -> Void) {
-        executeAction(completion) {
-            await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
+    public func getUnifiedAddress(accountIndex: Int, completion: @escaping (Result<UnifiedAddress, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
         }
     }
 
-    public func getTransparentAddress(accountIndex: Int, completion: @escaping (TransparentAddress?) -> Void) {
-        executeAction(completion) {
-            await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
+    public func getTransparentAddress(accountIndex: Int, completion: @escaping (Result<TransparentAddress, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
         }
     }
 
@@ -185,9 +185,17 @@ extension ClosureSDKSynchronizer: ClosureSynchronizer {
         }
     }
 
-    public func getShieldedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+    public func getShieldedBalance(accountIndex: Int, completion: @escaping (Result<Zatoshi, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getShieldedBalance(accountIndex: accountIndex)
+        }
+    }
 
-    public func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+    public func getShieldedVerifiedBalance(accountIndex: Int, completion: @escaping (Result<Zatoshi, Error>) -> Void) {
+        executeThrowingAction(completion) {
+            try await self.synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex)
+        }
+    }
 
     /*
      It can be missleading that these two methods are returning Publisher even this protocol is closure based. Reason is that Synchronizer doesn't

--- a/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/CombineSDKSynchronizer.swift
@@ -53,21 +53,21 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         }
     }
 
-    public func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress?, Never> {
-        return executeAction() {
-            await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
+    public func getSaplingAddress(accountIndex: Int) -> Single<SaplingAddress, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.getSaplingAddress(accountIndex: accountIndex)
         }
     }
 
-    public func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress?, Never> {
-        return executeAction() {
-            await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
+    public func getUnifiedAddress(accountIndex: Int) -> Single<UnifiedAddress, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.getUnifiedAddress(accountIndex: accountIndex)
         }
     }
 
-    public func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress?, Never> {
-        return executeAction() {
-            await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
+    public func getTransparentAddress(accountIndex: Int) -> Single<TransparentAddress, Error> {
+        return executeThrowingAction() {
+            try await self.synchronizer.getTransparentAddress(accountIndex: accountIndex)
         }
     }
 
@@ -178,9 +178,17 @@ extension CombineSDKSynchronizer: CombineSynchronizer {
         }
     }
 
-    public func getShieldedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedBalance(accountIndex: accountIndex) }
+    public func getShieldedBalance(accountIndex: Int = 0) -> Single<Zatoshi, Error> {
+        return executeThrowingAction() {
+            try await synchronizer.getShieldedBalance(accountIndex: accountIndex)
+        }
+    }
 
-    public func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi { synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex) }
+    public func getShieldedVerifiedBalance(accountIndex: Int = 0) -> Single<Zatoshi, Error> {
+        return executeThrowingAction() {
+            try await synchronizer.getShieldedVerifiedBalance(accountIndex: accountIndex)
+        }
+    }
 
     public func rewind(_ policy: RewindPolicy) -> Completable<Error> { synchronizer.rewind(policy) }
     public func wipe() -> Completable<Error> { synchronizer.wipe() }

--- a/Sources/ZcashLightClientKit/Tool/DerivationTool.swift
+++ b/Sources/ZcashLightClientKit/Tool/DerivationTool.swift
@@ -30,12 +30,12 @@ public protocol KeyDeriving {
     /// Extracts the `SaplingAddress` from the given `UnifiedAddress`
     /// - Parameter address: the `UnifiedAddress`
     /// - Throws `KeyDerivationErrors.receiverNotFound` if the receiver is not present
-    static func saplingReceiver(from unifiedAddress: UnifiedAddress) throws -> SaplingAddress?
+    static func saplingReceiver(from unifiedAddress: UnifiedAddress) throws -> SaplingAddress
 
     /// Extracts the `TransparentAddress` from the given `UnifiedAddress`
     /// - Parameter address: the `UnifiedAddress`
     /// - Throws `KeyDerivationErrors.receiverNotFound` if the receiver is not present
-    static func transparentReceiver(from unifiedAddress: UnifiedAddress) throws -> TransparentAddress?
+    static func transparentReceiver(from unifiedAddress: UnifiedAddress) throws -> TransparentAddress
 
     /// Extracts the `UnifiedAddress.ReceiverTypecodes` from the given `UnifiedAddress`
     /// - Parameter address: the `UnifiedAddress`
@@ -60,11 +60,11 @@ public class DerivationTool: KeyDeriving {
         self.networkType = networkType
     }
 
-    public static func saplingReceiver(from unifiedAddress: UnifiedAddress) throws -> SaplingAddress? {
+    public static func saplingReceiver(from unifiedAddress: UnifiedAddress) throws -> SaplingAddress {
         try rustwelding.getSaplingReceiver(for: unifiedAddress)
     }
 
-    public static func transparentReceiver(from unifiedAddress: UnifiedAddress) throws -> TransparentAddress? {
+    public static func transparentReceiver(from unifiedAddress: UnifiedAddress) throws -> TransparentAddress {
         try rustwelding.getTransparentReceiver(for: unifiedAddress)
     }
 
@@ -215,13 +215,13 @@ public extension UnifiedSpendingKey {
 public extension UnifiedAddress {
     /// Extracts the sapling receiver from this UA if available
     /// - Returns: an `Optional<SaplingAddress>`
-    func saplingReceiver() -> SaplingAddress? {
-        try? DerivationTool.saplingReceiver(from: self)
+    func saplingReceiver() throws -> SaplingAddress {
+        try DerivationTool.saplingReceiver(from: self)
     }
 
     /// Extracts the transparent receiver from this UA if available
     /// - Returns: an `Optional<TransparentAddress>`
-    func transparentReceiver() -> TransparentAddress? {
-        try? DerivationTool.transparentReceiver(from: self)
+    func transparentReceiver() throws -> TransparentAddress {
+        try DerivationTool.transparentReceiver(from: self)
     }
 }

--- a/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
+++ b/Sources/ZcashLightClientKit/Transaction/WalletTransactionEncoder.swift
@@ -58,7 +58,7 @@ class WalletTransactionEncoder: TransactionEncoder {
         memoBytes: MemoBytes?,
         from accountIndex: Int
     ) async throws -> ZcashTransaction.Overview {
-        let txId = try createSpend(
+        let txId = try await createSpend(
             spendingKey: spendingKey,
             zatoshi: zatoshi,
             to: address,
@@ -80,12 +80,12 @@ class WalletTransactionEncoder: TransactionEncoder {
         to address: String,
         memoBytes: MemoBytes?,
         from accountIndex: Int
-    ) throws -> Int {
+    ) async throws -> Int {
         guard ensureParams(spend: self.spendParamsURL, output: self.outputParamsURL) else {
             throw TransactionEncoderError.missingParams
         }
                 
-        let txId = rustBackend.createToAddress(
+        let txId = await rustBackend.createToAddress(
             dbData: self.dataDbURL,
             usk: spendingKey,
             to: address,
@@ -109,7 +109,7 @@ class WalletTransactionEncoder: TransactionEncoder {
         memoBytes: MemoBytes?,
         from accountIndex: Int
     ) async throws -> ZcashTransaction.Overview {
-        let txId = try createShieldingSpend(
+        let txId = try await createShieldingSpend(
             spendingKey: spendingKey,
             shieldingThreshold: shieldingThreshold,
             memo: memoBytes,
@@ -129,12 +129,12 @@ class WalletTransactionEncoder: TransactionEncoder {
         shieldingThreshold: Zatoshi,
         memo: MemoBytes?,
         accountIndex: Int
-    ) throws -> Int {
+    ) async throws -> Int {
         guard ensureParams(spend: self.spendParamsURL, output: self.outputParamsURL) else {
             throw TransactionEncoderError.missingParams
         }
         
-        let txId = rustBackend.shieldFunds(
+        let txId = await rustBackend.shieldFunds(
             dbData: self.dataDbURL,
             usk: spendingKey,
             memo: memo,

--- a/Tests/DarksideTests/BlockDownloaderTests.swift
+++ b/Tests/DarksideTests/BlockDownloaderTests.swift
@@ -25,8 +25,8 @@ class BlockDownloaderTests: XCTestCase {
     var storage: CompactBlockRepository!
     var network = DarksideWalletDNetwork()
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
         service = LightWalletServiceFactory(endpoint: LightWalletEndpointBuilder.default).make()
 
         storage = FSCompactBlockRepository(
@@ -40,7 +40,7 @@ class BlockDownloaderTests: XCTestCase {
             contentProvider: DirectoryListingProviders.defaultSorted,
             logger: logger
         )
-        try storage.create()
+        try await storage.create()
 
         downloader = BlockDownloaderServiceImpl(service: service, storage: storage)
         darksideWalletService = DarksideWalletService(endpoint: LightWalletEndpointBuilder.default, service: service as! LightWalletGRPCService)

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -264,8 +264,8 @@ final class SynchronizerTests: XCTestCase {
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName)
 
         try coordinator.applyStaged(blockheight: defaultLatestHeight)
-        let initialVerifiedBalance: Zatoshi = coordinator.synchronizer.initializer.getVerifiedBalance()
-        let initialTotalBalance: Zatoshi = coordinator.synchronizer.initializer.getBalance()
+        let initialVerifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
+        let initialTotalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         sleep(1)
         let firstSyncExpectation = XCTestExpectation(description: "first sync expectation")
 
@@ -306,8 +306,8 @@ final class SynchronizerTests: XCTestCase {
 
         wait(for: [waitExpectation], timeout: 1)
 
-        let verifiedBalance: Zatoshi = coordinator.synchronizer.initializer.getVerifiedBalance()
-        let totalBalance: Zatoshi = coordinator.synchronizer.initializer.getBalance()
+        let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
+        let totalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         // 2 check that there are no unconfirmed funds
         XCTAssertTrue(verifiedBalance > network.constants.defaultFee(for: defaultLatestHeight))
         XCTAssertEqual(verifiedBalance, totalBalance)
@@ -338,7 +338,9 @@ final class SynchronizerTests: XCTestCase {
         XCTAssertEqual(lastScannedHeight, self.birthday)
 
         // check that the balance is cleared
-        XCTAssertEqual(initialVerifiedBalance, coordinator.synchronizer.initializer.getVerifiedBalance())
-        XCTAssertEqual(initialTotalBalance, coordinator.synchronizer.initializer.getBalance())
+        let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
+        let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
+        XCTAssertEqual(initialVerifiedBalance, expectedVerifiedBalance)
+        XCTAssertEqual(initialTotalBalance, expectedBalance)
     }
 }

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -40,16 +40,16 @@ class TransactionEnhancementTests: XCTestCase {
     var txFoundNotificationExpectation: XCTestExpectation!
     var waitExpectation: XCTestExpectation!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
+
         try self.testFileManager.createDirectory(at: self.testTempDirectory, withIntermediateDirectories: false)
-        XCTestCase.wait {
-            await InternalSyncProgress(
-                alias: .default,
-                storage: UserDefaults.standard,
-                logger: logger
-            ).rewind(to: 0)
-        }
+
+        await InternalSyncProgress(
+            alias: .default,
+            storage: UserDefaults.standard,
+            logger: logger
+        ).rewind(to: 0)
 
         logger = OSLogger(logLevel: .debug)
         
@@ -81,7 +81,7 @@ class TransactionEnhancementTests: XCTestCase {
         try? FileManager.default.removeItem(at: processorConfig.fsBlockCacheRoot)
         try? FileManager.default.removeItem(at: processorConfig.dataDb)
 
-        let dbInit = try rustBackend.initDataDb(dbData: processorConfig.dataDb, seed: nil, networkType: network.networkType)
+        let dbInit = try await rustBackend.initDataDb(dbData: processorConfig.dataDb, seed: nil, networkType: network.networkType)
         
         let ufvks = [
             try DerivationTool(networkType: network.networkType)
@@ -92,7 +92,7 @@ class TransactionEnhancementTests: XCTestCase {
                 }
         ]
         do {
-            try rustBackend.initAccountsTable(
+            try await rustBackend.initAccountsTable(
                 dbData: processorConfig.dataDb,
                 ufvks: ufvks,
                 networkType: network.networkType
@@ -107,7 +107,7 @@ class TransactionEnhancementTests: XCTestCase {
             return
         }
 
-        _ = try rustBackend.initBlocksTable(
+        _ = try await rustBackend.initBlocksTable(
             dbData: processorConfig.dataDb,
             height: Int32(birthday.height),
             hash: birthday.hash,
@@ -130,7 +130,7 @@ class TransactionEnhancementTests: XCTestCase {
             contentProvider: DirectoryListingProviders.defaultSorted,
             logger: logger
         )
-        try! storage.create()
+        try! await storage.create()
         
         downloader = BlockDownloaderServiceImpl(service: service, storage: storage)
         processor = CompactBlockProcessor(
@@ -149,7 +149,7 @@ class TransactionEnhancementTests: XCTestCase {
             }
         }
 
-        XCTestCase.wait { await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure) }
+        await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure)
     }
     
     override func tearDownWithError() throws {

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -68,7 +68,7 @@ class BlockScanTests: XCTestCase {
     func testSingleDownloadAndScan() async throws {
         logger = OSLogger(logLevel: .debug)
 
-        XCTAssertNoThrow(try rustWelding.initDataDb(dbData: dataDbURL, seed: nil, networkType: network.networkType))
+        _ = try await rustWelding.initDataDb(dbData: dataDbURL, seed: nil, networkType: network.networkType)
 
         let endpoint = LightWalletEndpoint(address: "lightwalletd.testnet.electriccoin.co", port: 9067)
         let service = LightWalletServiceFactory(endpoint: endpoint).make()
@@ -90,7 +90,7 @@ class BlockScanTests: XCTestCase {
             logger: logger
         )
 
-        try fsBlockRepository.create()
+        try await fsBlockRepository.create()
 
         let processorConfig = CompactBlockProcessor.Configuration(
             alias: .default,
@@ -139,7 +139,7 @@ class BlockScanTests: XCTestCase {
         let metrics = SDKMetrics()
         metrics.enableMetrics()
         
-        guard try self.rustWelding.initDataDb(dbData: dataDbURL, seed: nil, networkType: network.networkType) == .success else {
+        guard try await self.rustWelding.initDataDb(dbData: dataDbURL, seed: nil, networkType: network.networkType) == .success else {
             XCTFail("Seed should not be required for this test")
             return
         }
@@ -150,7 +150,7 @@ class BlockScanTests: XCTestCase {
             .map { try derivationTool.deriveUnifiedFullViewingKey(from: $0) }
 
         do {
-            try self.rustWelding.initAccountsTable(
+            try await self.rustWelding.initAccountsTable(
                 dbData: self.dataDbURL,
                 ufvks: [ufvk],
                 networkType: network.networkType
@@ -160,7 +160,7 @@ class BlockScanTests: XCTestCase {
             return
         }
         
-        try self.rustWelding.initBlocksTable(
+        try await self.rustWelding.initBlocksTable(
             dbData: dataDbURL,
             height: Int32(walletBirthDay.height),
             hash: walletBirthDay.hash,
@@ -185,7 +185,7 @@ class BlockScanTests: XCTestCase {
             logger: logger
         )
 
-        try fsBlockRepository.create()
+        try await fsBlockRepository.create()
         
         var processorConfig = CompactBlockProcessor.Configuration(
             alias: .default,

--- a/Tests/NetworkTests/BlockStreamingTest.swift
+++ b/Tests/NetworkTests/BlockStreamingTest.swift
@@ -82,7 +82,7 @@ class BlockStreamingTest: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let latestBlockHeight = try await service.latestBlockHeight()
         let startHeight = latestBlockHeight - 100_000
@@ -146,7 +146,7 @@ class BlockStreamingTest: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let latestBlockHeight = try await service.latestBlockHeight()
 

--- a/Tests/NetworkTests/CompactBlockProcessorTests.swift
+++ b/Tests/NetworkTests/CompactBlockProcessorTests.swift
@@ -42,18 +42,16 @@ class CompactBlockProcessorTests: XCTestCase {
 
     let testFileManager = FileManager()
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
         logger = OSLogger(logLevel: .debug)
         try self.testFileManager.createDirectory(at: self.testTempDirectory, withIntermediateDirectories: false)
 
-        XCTestCase.wait {
-            await InternalSyncProgress(
-                alias: .default,
-                storage: UserDefaults.standard,
-                logger: logger
-            ).rewind(to: 0)
-        }
+        await InternalSyncProgress(
+            alias: .default,
+            storage: UserDefaults.standard,
+            logger: logger
+        ).rewind(to: 0)
 
         let liveService = LightWalletServiceFactory(endpoint: LightWalletEndpointBuilder.eccTestnet).make()
         let service = MockLightWalletService(
@@ -86,7 +84,7 @@ class CompactBlockProcessorTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
         
         processor = CompactBlockProcessor(
             service: service,
@@ -97,7 +95,7 @@ class CompactBlockProcessorTests: XCTestCase {
             logger: logger
         )
 
-        let dbInit = try realRustBackend.initDataDb(dbData: processorConfig.dataDb, seed: nil, networkType: .testnet)
+        let dbInit = try await realRustBackend.initDataDb(dbData: processorConfig.dataDb, seed: nil, networkType: .testnet)
 
         guard case .success = dbInit else {
             XCTFail("Failed to initDataDb. Expected `.success` got: \(dbInit)")
@@ -116,7 +114,7 @@ class CompactBlockProcessorTests: XCTestCase {
             }
         }
 
-        XCTestCase.wait { await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure) }
+        await self.processor.updateEventClosure(identifier: "tests", closure: eventClosure)
     }
     
     override func tearDownWithError() throws {

--- a/Tests/NetworkTests/DownloadTests.swift
+++ b/Tests/NetworkTests/DownloadTests.swift
@@ -49,7 +49,7 @@ class DownloadTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let blockCount = 100
         let activationHeight = network.constants.saplingActivationHeight

--- a/Tests/OfflineTests/BlockBatchValidationTests.swift
+++ b/Tests/OfflineTests/BlockBatchValidationTests.swift
@@ -48,7 +48,7 @@ class BlockBatchValidationTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let repository = ZcashConsoleFakeStorage(latestBlockHeight: 1220000)
         let downloaderService = BlockDownloaderServiceImpl(service: service, storage: repository)
@@ -123,7 +123,7 @@ class BlockBatchValidationTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let repository = ZcashConsoleFakeStorage(latestBlockHeight: 1220000)
         let downloaderService = BlockDownloaderServiceImpl(service: service, storage: repository)
@@ -198,7 +198,7 @@ class BlockBatchValidationTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let repository = ZcashConsoleFakeStorage(latestBlockHeight: 1220000)
         let downloaderService = BlockDownloaderServiceImpl(service: service, storage: repository)
@@ -273,7 +273,7 @@ class BlockBatchValidationTests: XCTestCase {
             logger: logger
         )
 
-        try storage.create()
+        try await storage.create()
 
         let repository = ZcashConsoleFakeStorage(latestBlockHeight: 1220000)
         let downloaderService = BlockDownloaderServiceImpl(service: service, storage: repository)

--- a/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
@@ -210,9 +210,33 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
 
         let expectation = XCTestExpectation()
 
-        synchronizer.getSaplingAddress(accountIndex: 3) { receivedAddress in
-            XCTAssertEqual(receivedAddress, self.data.saplingAddress)
-            expectation.fulfill()
+        synchronizer.getSaplingAddress(accountIndex: 3) { result in
+            switch result {
+            case let .success(address):
+                XCTAssertEqual(address, self.data.saplingAddress)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("getSaplingAddress failed with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetSaplingAddressThrowsError() {
+        synchronizerMock.getSaplingAddressAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getSaplingAddress(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
         }
 
         wait(for: [expectation], timeout: 0.5)
@@ -226,9 +250,33 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
 
         let expectation = XCTestExpectation()
 
-        synchronizer.getUnifiedAddress(accountIndex: 3) { receivedAddress in
-            XCTAssertEqual(receivedAddress, self.data.unifiedAddress)
-            expectation.fulfill()
+        synchronizer.getUnifiedAddress(accountIndex: 3) { result in
+            switch result {
+            case let .success(address):
+                XCTAssertEqual(address, self.data.unifiedAddress)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("getSaplingAddress failed with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetUnifiedAddressThrowsError() {
+        synchronizerMock.getUnifiedAddressAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getUnifiedAddress(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
         }
 
         wait(for: [expectation], timeout: 0.5)
@@ -242,9 +290,33 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
 
         let expectation = XCTestExpectation()
 
-        synchronizer.getTransparentAddress(accountIndex: 3) { receivedAddress in
-            XCTAssertEqual(receivedAddress, self.data.transparentAddress)
-            expectation.fulfill()
+        synchronizer.getTransparentAddress(accountIndex: 3) { result in
+            switch result {
+            case let .success(address):
+                XCTAssertEqual(address, self.data.transparentAddress)
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("getSaplingAddress failed with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetTransparentAddressThrowsError() {
+        synchronizerMock.getTransparentAddressAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getTransparentAddress(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
         }
 
         wait(for: [expectation], timeout: 0.5)
@@ -762,7 +834,38 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return Zatoshi(333)
         }
 
-        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), Zatoshi(333))
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedBalance(accountIndex: 3) { result in
+            switch result {
+            case let .success(receivedBalance):
+                XCTAssertEqual(receivedBalance, Zatoshi(333))
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedBalanceThrowsError() {
+        synchronizerMock.getShieldedBalanceAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedBalance(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetShieldedVerifiedBalanceSucceed() {
@@ -771,7 +874,38 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
             return Zatoshi(333)
         }
 
-        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), Zatoshi(333))
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedVerifiedBalance(accountIndex: 3) { result in
+            switch result {
+            case let .success(receivedBalance):
+                XCTAssertEqual(receivedBalance, Zatoshi(333))
+                expectation.fulfill()
+            case let .failure(error):
+                XCTFail("Unpected failure with error: \(error)")
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedVerifiedBalanceThrowsError() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedVerifiedBalance(accountIndex: 3) { result in
+            switch result {
+            case .success:
+                XCTFail("Error should be thrown.")
+            case .failure:
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testRewindSucceed() {

--- a/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
@@ -1023,7 +1023,51 @@ class CombineSynchronizerOfflineTests: XCTestCase {
             return Zatoshi(333)
         }
 
-        XCTAssertEqual(synchronizer.getShieldedBalance(accountIndex: 3), Zatoshi(333))
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, Zatoshi(333))
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedBalanceThrowsError() {
+        synchronizerMock.getShieldedBalanceAccountIndexClosure = { _ in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testGetShieldedVerifiedBalanceSucceed() {
@@ -1032,7 +1076,51 @@ class CombineSynchronizerOfflineTests: XCTestCase {
             return Zatoshi(333)
         }
 
-        XCTAssertEqual(synchronizer.getShieldedVerifiedBalance(accountIndex: 3), Zatoshi(333))
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedVerifiedBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        expectation.fulfill()
+                    case let .failure(error):
+                        XCTFail("Unpected failure with error: \(error)")
+                    }
+                },
+                receiveValue: { value in
+                    XCTAssertEqual(value, Zatoshi(333))
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testGetShieldedVerifiedBalanceThrowsError() {
+        synchronizerMock.getShieldedVerifiedBalanceAccountIndexClosure = { receivedAccountIndex in
+            throw "Some error"
+        }
+
+        let expectation = XCTestExpectation()
+
+        synchronizer.getShieldedVerifiedBalance(accountIndex: 3)
+            .sink(
+                receiveCompletion: { result in
+                    switch result {
+                    case .finished:
+                        XCTFail("Error should be thrown.")
+                    case .failure:
+                        expectation.fulfill()
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("No value is expected")
+                }
+            )
+            .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testRewindSucceed() {

--- a/Tests/OfflineTests/CompactBlockRepositoryTests.swift
+++ b/Tests/OfflineTests/CompactBlockRepositoryTests.swift
@@ -44,7 +44,7 @@ class CompactBlockRepositoryTests: XCTestCase {
             logger: logger
         )
 
-        try compactBlockRepository.create()
+        try await compactBlockRepository.create()
 
         let latestHeight = await compactBlockRepository.latestHeight()
         XCTAssertEqual(latestHeight, BlockHeight.empty())
@@ -63,7 +63,7 @@ class CompactBlockRepositoryTests: XCTestCase {
             logger: logger
         )
 
-        try compactBlockRepository.create()
+        try await compactBlockRepository.create()
 
         let initialHeight = await compactBlockRepository.latestHeight()
         let startHeight = self.network.constants.saplingActivationHeight
@@ -90,7 +90,7 @@ class CompactBlockRepositoryTests: XCTestCase {
             logger: logger
         )
 
-        try compactBlockRepository.create()
+        try await compactBlockRepository.create()
 
         let expectedHeight = BlockHeight(123_456)
         guard let block = StubBlockCreator.createRandomDataBlock(with: expectedHeight) else {
@@ -116,7 +116,7 @@ class CompactBlockRepositoryTests: XCTestCase {
             logger: logger
         )
 
-        try compactBlockRepository.create()
+        try await compactBlockRepository.create()
 
         let startHeight = self.network.constants.saplingActivationHeight
         let blockCount = Int(1_000)

--- a/Tests/OfflineTests/NotesRepositoryTests.swift
+++ b/Tests/OfflineTests/NotesRepositoryTests.swift
@@ -13,10 +13,10 @@ class NotesRepositoryTests: XCTestCase {
     var sentNotesRepository: SentNotesRepository!
     var receivedNotesRepository: ReceivedNoteRepository!
 
-    override func setUp() {
-        super.setUp()
-        sentNotesRepository = try! TestDbBuilder.sentNotesRepository()
-        receivedNotesRepository = try! TestDbBuilder.receivedNotesRepository()
+    override func setUp() async throws {
+        try await super.setUp()
+        sentNotesRepository = try! await TestDbBuilder.sentNotesRepository()
+        receivedNotesRepository = try! await TestDbBuilder.receivedNotesRepository()
     }
     
     override func tearDown() {

--- a/Tests/OfflineTests/NullBytesTests.swift
+++ b/Tests/OfflineTests/NullBytesTests.swift
@@ -28,7 +28,7 @@ class NullBytesTests: XCTestCase {
         XCTAssertFalse(ZcashRustBackend.isValidTransparentAddress(tAddrWithNullBytes, networkType: networkType))
     }
     
-    func testInitAccountTableNullBytes() throws {
+    func testInitAccountTableNullBytes() async throws {
         let wrongHash = "000000000\015c597fab53f\058b9e1ededbe8bd83ca0203788e2039eceeb0d65ca6"
         let goodHash = "00000000015c597fab53f58b9e1ededbe8bd83ca0203788e2039eceeb0d65ca6"
         let time: UInt32 = 1582235356
@@ -49,23 +49,23 @@ class NullBytesTests: XCTestCase {
         bccb48b14b544e770f21d48f2d3ad8d6ca54eccc92f60634e3078eb48013a1f7fb005388ac6f04099b647ed85d8b025d8ae4b178c2376b473b121b8c052000001d2ea556f49fb\
         934dc76f087935a5c07788000b4e3aae24883adfec51b5f4d260
         """
-        
-        XCTAssertThrowsError(
-            try ZcashRustBackend.initBlocksTable(
+
+        do {
+            _ = try await ZcashRustBackend.initBlocksTable(
                 dbData: __dataDbURL(),
                 height: height,
                 hash: wrongHash,
                 time: time,
                 saplingTree: goodTree,
                 networkType: networkType
-            ),
-            "InitBlocksTable with Null bytes on hash string should have failed"
-        ) { error in
+            )
+            XCTFail("InitBlocksTable with Null bytes on hash string should have failed")
+        } catch {
             guard let rustError = error as? RustWeldingError else {
                 XCTFail("Expected RustWeldingError")
                 return
             }
-            
+
             switch rustError {
             case .invalidInput:
                 XCTAssertTrue(true)
@@ -73,23 +73,23 @@ class NullBytesTests: XCTestCase {
                 XCTFail("expected \(String(describing: RustWeldingError.invalidInput)) and got \(rustError)")
             }
         }
-        
-        XCTAssertThrowsError(
-            try ZcashRustBackend.initBlocksTable(
+
+        do {
+            try await ZcashRustBackend.initBlocksTable(
                 dbData: __dataDbURL(),
                 height: height,
                 hash: goodHash,
                 time: time,
                 saplingTree: wrongTree,
                 networkType: networkType
-            ),
-            "InitBlocksTable with Null bytes on saplingTree string should have failed"
-        ) { error in
+            )
+            XCTFail("InitBlocksTable with Null bytes on saplingTree string should have failed")
+        } catch {
             guard let rustError = error as? RustWeldingError else {
                 XCTFail("Expected RustWeldingError")
                 return
             }
-            
+
             switch rustError {
             case .invalidInput:
                 XCTAssertTrue(true)

--- a/Tests/OfflineTests/TransactionRepositoryTests.swift
+++ b/Tests/OfflineTests/TransactionRepositoryTests.swift
@@ -11,11 +11,10 @@ import XCTest
 
 class TransactionRepositoryTests: XCTestCase {
     var transactionRepository: TransactionRepository!
-    
-    override func setUp() {
-        super.setUp()
 
-        transactionRepository = try! TestDbBuilder.transactionRepository()
+    override func setUp() async throws {
+        try await super.setUp()
+        transactionRepository = try! await TestDbBuilder.transactionRepository()
     }
     
     override func tearDown() {

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -71,25 +71,25 @@ class MockRustBackend: ZcashRustBackendWelding {
     static var consensusBranchID: Int32?
     static var writeBlocksMetadataResult: () throws -> Bool = { true }
     static var rewindCacheToHeightResult: () -> Bool = { true }
-    static func latestCachedBlockHeight(fsBlockDbRoot: URL) -> ZcashLightClientKit.BlockHeight {
+    static func latestCachedBlockHeight(fsBlockDbRoot: URL) async -> ZcashLightClientKit.BlockHeight {
         .empty()
     }
 
-    static func rewindCacheToHeight(fsBlockDbRoot: URL, height: Int32) -> Bool {
+    static func rewindCacheToHeight(fsBlockDbRoot: URL, height: Int32) async -> Bool {
         rewindCacheToHeightResult()
     }
 
-    static func initBlockMetadataDb(fsBlockDbRoot: URL) throws -> Bool {
+    static func initBlockMetadataDb(fsBlockDbRoot: URL) async throws -> Bool {
         true
     }
 
-    static func writeBlocksMetadata(fsBlockDbRoot: URL, blocks: [ZcashLightClientKit.ZcashCompactBlock]) throws -> Bool {
+    static func writeBlocksMetadata(fsBlockDbRoot: URL, blocks: [ZcashLightClientKit.ZcashCompactBlock]) async throws -> Bool {
         try writeBlocksMetadataResult()
     }
 
-    static func initAccountsTable(dbData: URL, ufvks: [ZcashLightClientKit.UnifiedFullViewingKey], networkType: ZcashLightClientKit.NetworkType) throws { }
+    static func initAccountsTable(dbData: URL, ufvks: [ZcashLightClientKit.UnifiedFullViewingKey], networkType: ZcashLightClientKit.NetworkType) async throws { }
 
-    static func createToAddress(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, to address: String, value: Int64, memo: ZcashLightClientKit.MemoBytes?, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) -> Int64 {
+    static func createToAddress(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, to address: String, value: Int64, memo: ZcashLightClientKit.MemoBytes?, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) async -> Int64 {
         -1
     }
 
@@ -101,7 +101,7 @@ class MockRustBackend: ZcashRustBackendWelding {
         spendParamsPath: String,
         outputParamsPath: String,
         networkType: ZcashLightClientKit.NetworkType
-    ) -> Int64 {
+    ) async -> Int64 {
         -1
     }
 
@@ -109,15 +109,15 @@ class MockRustBackend: ZcashRustBackendWelding {
         nil
     }
     
-    static func clearUtxos(dbData: URL, address: ZcashLightClientKit.TransparentAddress, sinceHeight: ZcashLightClientKit.BlockHeight, networkType: ZcashLightClientKit.NetworkType) throws -> Int32 {
+    static func clearUtxos(dbData: URL, address: ZcashLightClientKit.TransparentAddress, sinceHeight: ZcashLightClientKit.BlockHeight, networkType: ZcashLightClientKit.NetworkType) async throws -> Int32 {
         0
     }
 
-    static func getTransparentBalance(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) throws -> Int64 { 0 }
+    static func getTransparentBalance(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) async throws -> Int64 { 0 }
 
-    static func getVerifiedTransparentBalance(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) throws -> Int64 { 0 }
+    static func getVerifiedTransparentBalance(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) async throws -> Int64 { 0 }
 
-    static func listTransparentReceivers(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) throws -> [ZcashLightClientKit.TransparentAddress] {
+    static func listTransparentReceivers(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) async throws -> [ZcashLightClientKit.TransparentAddress] {
         []
     }
 
@@ -129,23 +129,23 @@ class MockRustBackend: ZcashRustBackendWelding {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func getCurrentAddress(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) throws -> ZcashLightClientKit.UnifiedAddress {
+    static func getCurrentAddress(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) async throws -> ZcashLightClientKit.UnifiedAddress {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func getNextAvailableAddress(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) throws -> ZcashLightClientKit.UnifiedAddress {
+    static func getNextAvailableAddress(dbData: URL, account: Int32, networkType: ZcashLightClientKit.NetworkType) async throws -> ZcashLightClientKit.UnifiedAddress {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func getSaplingReceiver(for uAddr: ZcashLightClientKit.UnifiedAddress) throws -> ZcashLightClientKit.SaplingAddress? {
+    static func getSaplingReceiver(for uAddr: ZcashLightClientKit.UnifiedAddress) throws -> ZcashLightClientKit.SaplingAddress {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func getTransparentReceiver(for uAddr: ZcashLightClientKit.UnifiedAddress) throws -> ZcashLightClientKit.TransparentAddress? {
+    static func getTransparentReceiver(for uAddr: ZcashLightClientKit.UnifiedAddress) throws -> ZcashLightClientKit.TransparentAddress {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func shieldFunds(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, memo: ZcashLightClientKit.MemoBytes, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) -> Int64 {
+    static func shieldFunds(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, memo: ZcashLightClientKit.MemoBytes, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) async -> Int64 {
         -1
     }
 
@@ -153,19 +153,19 @@ class MockRustBackend: ZcashRustBackendWelding {
         throw KeyDerivationErrors.receiverNotFound
     }
 
-    static func createAccount(dbData: URL, seed: [UInt8], networkType: ZcashLightClientKit.NetworkType) throws -> ZcashLightClientKit.UnifiedSpendingKey {
+    static func createAccount(dbData: URL, seed: [UInt8], networkType: ZcashLightClientKit.NetworkType) async throws -> ZcashLightClientKit.UnifiedSpendingKey {
         throw KeyDerivationErrors.unableToDerive
     }
 
-    static func getReceivedMemo(dbData: URL, idNote: Int64, networkType: ZcashLightClientKit.NetworkType) -> ZcashLightClientKit.Memo? { nil }
+    static func getReceivedMemo(dbData: URL, idNote: Int64, networkType: ZcashLightClientKit.NetworkType) async -> ZcashLightClientKit.Memo? { nil }
 
-    static func getSentMemo(dbData: URL, idNote: Int64, networkType: ZcashLightClientKit.NetworkType) -> ZcashLightClientKit.Memo? { nil }
+    static func getSentMemo(dbData: URL, idNote: Int64, networkType: ZcashLightClientKit.NetworkType) async -> ZcashLightClientKit.Memo? { nil }
 
-    static func createToAddress(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, to address: String, value: Int64, memo: ZcashLightClientKit.MemoBytes, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) -> Int64 {
+    static func createToAddress(dbData: URL, usk: ZcashLightClientKit.UnifiedSpendingKey, to address: String, value: Int64, memo: ZcashLightClientKit.MemoBytes, spendParamsPath: String, outputParamsPath: String, networkType: ZcashLightClientKit.NetworkType) async -> Int64 {
         -1
     }
 
-    static func initDataDb(dbData: URL, seed: [UInt8]?, networkType: ZcashLightClientKit.NetworkType) throws -> ZcashLightClientKit.DbInitResult {
+    static func initDataDb(dbData: URL, seed: [UInt8]?, networkType: ZcashLightClientKit.NetworkType) async throws -> ZcashLightClientKit.DbInitResult {
         .seedRequired
     }
 
@@ -189,11 +189,11 @@ class MockRustBackend: ZcashRustBackendWelding {
 
     public func deriveViewingKeys(seed: [UInt8], numberOfAccounts: Int) throws -> [UnifiedFullViewingKey] { [] }
     
-    static func getNearestRewindHeight(dbData: URL, height: Int32, networkType: NetworkType) -> Int32 { -1 }
+    static func getNearestRewindHeight(dbData: URL, height: Int32, networkType: NetworkType) async -> Int32 { -1 }
     
-    static func network(dbData: URL, address: String, sinceHeight: BlockHeight, networkType: NetworkType) throws -> Int32 { -1 }
+    static func network(dbData: URL, address: String, sinceHeight: BlockHeight, networkType: NetworkType) async throws -> Int32 { -1 }
     
-    static func initAccountsTable(dbData: URL, ufvks: [UnifiedFullViewingKey], networkType: NetworkType) throws -> Bool { false }
+    static func initAccountsTable(dbData: URL, ufvks: [UnifiedFullViewingKey], networkType: NetworkType) async throws -> Bool { false }
     
     static func putUnspentTransparentOutput(
         dbData: URL,
@@ -203,11 +203,11 @@ class MockRustBackend: ZcashRustBackendWelding {
         value: Int64,
         height: BlockHeight,
         networkType: NetworkType
-    ) throws -> Bool {
+    ) async throws -> Bool {
         false
     }
     
-    static func downloadedUtxoBalance(dbData: URL, address: String, networkType: NetworkType) throws -> WalletBalance {
+    static func downloadedUtxoBalance(dbData: URL, address: String, networkType: NetworkType) async throws -> WalletBalance {
         throw RustWeldingError.genericError(message: "unimplemented")
     }
     
@@ -221,7 +221,7 @@ class MockRustBackend: ZcashRustBackendWelding {
         spendParamsPath: String,
         outputParamsPath: String,
         networkType: NetworkType
-    ) -> Int64 {
+    ) async -> Int64 {
         -1
     }
 
@@ -262,9 +262,9 @@ class MockRustBackend: ZcashRustBackendWelding {
         true
     }
     
-    static func initDataDb(dbData: URL, networkType: NetworkType) throws {
+    static func initDataDb(dbData: URL, networkType: NetworkType) async throws {
         if !mockDataDb {
-            _ = try rustBackend.initDataDb(dbData: dbData, seed: nil, networkType: networkType)
+            _ = try await rustBackend.initDataDb(dbData: dbData, seed: nil, networkType: networkType)
         }
     }
 
@@ -275,9 +275,9 @@ class MockRustBackend: ZcashRustBackendWelding {
         time: UInt32,
         saplingTree: String,
         networkType: NetworkType
-    ) throws {
+    ) async throws {
         if !mockDataDb {
-            try rustBackend.initBlocksTable(
+            try await rustBackend.initBlocksTable(
                 dbData: dbData,
                 height: height,
                 hash: hash,
@@ -288,66 +288,66 @@ class MockRustBackend: ZcashRustBackendWelding {
         }
     }
     
-    static func getBalance(dbData: URL, account: Int32, networkType: NetworkType) throws -> Int64 {
+    static func getBalance(dbData: URL, account: Int32, networkType: NetworkType) async throws -> Int64 {
         if let balance = mockBalance {
             return balance
         }
-        return try rustBackend.getBalance(dbData: dbData, account: account, networkType: networkType)
+        return try await rustBackend.getBalance(dbData: dbData, account: account, networkType: networkType)
     }
     
-    static func getVerifiedBalance(dbData: URL, account: Int32, networkType: NetworkType) throws -> Int64 {
+    static func getVerifiedBalance(dbData: URL, account: Int32, networkType: NetworkType) async throws -> Int64 {
         if let balance = mockVerifiedBalance {
             return balance
         }
 
-        return try rustBackend.getVerifiedBalance(dbData: dbData, account: account, networkType: networkType)
+        return try await rustBackend.getVerifiedBalance(dbData: dbData, account: account, networkType: networkType)
     }
     
-    static func validateCombinedChain(fsBlockDbRoot: URL, dbData: URL, networkType: NetworkType, limit: UInt32 = 0) -> Int32 {
+    static func validateCombinedChain(fsBlockDbRoot: URL, dbData: URL, networkType: NetworkType, limit: UInt32 = 0) async -> Int32 {
         if let rate = self.mockValidateCombinedChainSuccessRate {
             if shouldSucceed(successRate: rate) {
-                return validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+                return await validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
             } else {
                 return Int32(mockValidateCombinedChainFailureHeight)
             }
         } else if let attempts = self.mockValidateCombinedChainFailAfterAttempts {
             self.mockValidateCombinedChainFailAfterAttempts = attempts - 1
             if attempts > 0 {
-                return validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+                return await validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
             } else {
                 if attempts == 0 {
                     return Int32(mockValidateCombinedChainFailureHeight)
                 } else if attempts < 0 && mockValidateCombinedChainKeepFailing {
                     return Int32(mockValidateCombinedChainFailureHeight)
                 } else {
-                    return validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+                    return await validationResult(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
                 }
             }
         }
-        return rustBackend.validateCombinedChain(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+        return await rustBackend.validateCombinedChain(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
     }
     
-    private static func validationResult(fsBlockDbRoot: URL, dbData: URL, networkType: NetworkType) -> Int32 {
+    private static func validationResult(fsBlockDbRoot: URL, dbData: URL, networkType: NetworkType) async -> Int32 {
         if mockDataDb {
             return -1
         } else {
-            return rustBackend.validateCombinedChain(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+            return await rustBackend.validateCombinedChain(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
         }
     }
     
-    static func rewindToHeight(dbData: URL, height: Int32, networkType: NetworkType) -> Bool {
+    static func rewindToHeight(dbData: URL, height: Int32, networkType: NetworkType) async -> Bool {
         mockDataDb ? true : rustBackend.rewindToHeight(dbData: dbData, height: height, networkType: networkType)
     }
     
-    static func scanBlocks(fsBlockDbRoot: URL, dbData: URL, limit: UInt32, networkType: NetworkType) -> Bool {
+    static func scanBlocks(fsBlockDbRoot: URL, dbData: URL, limit: UInt32, networkType: NetworkType) async -> Bool {
         if let rate = mockScanblocksSuccessRate {
             if shouldSucceed(successRate: rate) {
-                return mockDataDb ? true : rustBackend.scanBlocks(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
+                return mockDataDb ? true : await rustBackend.scanBlocks(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: networkType)
             } else {
                 return false
             }
         }
-        return rustBackend.scanBlocks(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: Self.networkType)
+        return await rustBackend.scanBlocks(fsBlockDbRoot: fsBlockDbRoot, dbData: dbData, networkType: Self.networkType)
     }
     
     static func createToAddress(
@@ -361,7 +361,7 @@ class MockRustBackend: ZcashRustBackendWelding {
         spendParamsPath: String,
         outputParamsPath: String,
         networkType: NetworkType
-    ) -> Int64 {
+    ) async -> Int64 {
         -1
     }
     
@@ -382,7 +382,7 @@ class MockRustBackend: ZcashRustBackendWelding {
         nil
     }
     
-    static func decryptAndStoreTransaction(dbData: URL, txBytes: [UInt8], minedHeight: Int32, networkType: NetworkType) -> Bool {
+    static func decryptAndStoreTransaction(dbData: URL, txBytes: [UInt8], minedHeight: Int32, networkType: NetworkType) async -> Bool {
         false
     }
 }

--- a/Tests/TestUtils/SynchronizerMock.swift
+++ b/Tests/TestUtils/SynchronizerMock.swift
@@ -50,19 +50,19 @@ class SynchronizerMock: Synchronizer {
         await stopClosure()
     }
 
-    var getSaplingAddressAccountIndexClosure: ((Int) async -> SaplingAddress?)! = nil
-    func getSaplingAddress(accountIndex: Int) async -> SaplingAddress? {
-        return await getSaplingAddressAccountIndexClosure(accountIndex)
+    var getSaplingAddressAccountIndexClosure: ((Int) async throws -> SaplingAddress)! = nil
+    func getSaplingAddress(accountIndex: Int) async throws -> SaplingAddress {
+        return try await getSaplingAddressAccountIndexClosure(accountIndex)
     }
 
-    var getUnifiedAddressAccountIndexClosure: ((Int) async -> UnifiedAddress?)! = nil
-    func getUnifiedAddress(accountIndex: Int) async -> UnifiedAddress? {
-        return await getUnifiedAddressAccountIndexClosure(accountIndex)
+    var getUnifiedAddressAccountIndexClosure: ((Int) async throws -> UnifiedAddress)! = nil
+    func getUnifiedAddress(accountIndex: Int) async throws -> UnifiedAddress {
+        return try await getUnifiedAddressAccountIndexClosure(accountIndex)
     }
 
-    var getTransparentAddressAccountIndexClosure: ((Int) async -> TransparentAddress?)! = nil
-    func getTransparentAddress(accountIndex: Int) async -> TransparentAddress? {
-        return await getTransparentAddressAccountIndexClosure(accountIndex)
+    var getTransparentAddressAccountIndexClosure: ((Int) async throws -> TransparentAddress)! = nil
+    func getTransparentAddress(accountIndex: Int) async throws -> TransparentAddress {
+        return try await getTransparentAddressAccountIndexClosure(accountIndex)
     }
 
     var sendToAddressSpendingKeyZatoshiToAddressMemoClosure: (
@@ -152,14 +152,14 @@ class SynchronizerMock: Synchronizer {
         return try await getTransparentBalanceAccountIndexClosure(accountIndex)
     }
 
-    var getShieldedBalanceAccountIndexClosure: ((Int) -> Zatoshi)! = nil
-    func getShieldedBalance(accountIndex: Int) -> Zatoshi {
-        return getShieldedBalanceAccountIndexClosure(accountIndex)
+    var getShieldedBalanceAccountIndexClosure: ((Int) async throws -> Zatoshi)! = nil
+    func getShieldedBalance(accountIndex: Int) async throws -> Zatoshi {
+        try await getShieldedBalanceAccountIndexClosure(accountIndex)
     }
 
-    var getShieldedVerifiedBalanceAccountIndexClosure: ((Int) -> Zatoshi)! = nil
-    func getShieldedVerifiedBalance(accountIndex: Int) -> Zatoshi {
-        return getShieldedVerifiedBalanceAccountIndexClosure(accountIndex)
+    var getShieldedVerifiedBalanceAccountIndexClosure: ((Int) async throws -> Zatoshi)! = nil
+    func getShieldedVerifiedBalance(accountIndex: Int) async throws -> Zatoshi {
+        try await getShieldedVerifiedBalanceAccountIndexClosure(accountIndex)
     }
 
     var rewindPolicyClosure: ((RewindPolicy) -> AnyPublisher<Void, Error>)! = nil

--- a/Tests/TestUtils/TestDbBuilder.swift
+++ b/Tests/TestUtils/TestDbBuilder.swift
@@ -58,12 +58,12 @@ enum TestDbBuilder {
         Bundle.module.url(forResource: "darkside_caches", withExtension: "db")
     }
     
-    static func prepopulatedDataDbProvider() throws -> ConnectionProvider? {
+    static func prepopulatedDataDbProvider() async throws -> ConnectionProvider? {
         guard let url = prePopulatedMainnetDataDbURL() else { return nil }
 
         let provider = SimpleConnectionProvider(path: url.absoluteString, readonly: true)
 
-        let initResult = try ZcashRustBackend.initDataDb(
+        let initResult = try await ZcashRustBackend.initDataDb(
             dbData: url,
             seed: Environment.seedBytes,
             networkType: .mainnet
@@ -76,19 +76,19 @@ enum TestDbBuilder {
         }
     }
     
-    static func transactionRepository() throws -> TransactionRepository? {
-        guard let provider = try prepopulatedDataDbProvider() else { return nil }
+    static func transactionRepository() async throws -> TransactionRepository? {
+        guard let provider = try await prepopulatedDataDbProvider() else { return nil }
         
         return TransactionSQLDAO(dbProvider: provider)
     }
     
-    static func sentNotesRepository() throws -> SentNotesRepository? {
-        guard let provider = try prepopulatedDataDbProvider() else { return nil }
+    static func sentNotesRepository() async throws -> SentNotesRepository? {
+        guard let provider = try await prepopulatedDataDbProvider() else { return nil }
         return SentNotesSQLDAO(dbProvider: provider)
     }
     
-    static func receivedNotesRepository() throws -> ReceivedNoteRepository? {
-        guard let provider = try prepopulatedDataDbProvider() else { return nil }
+    static func receivedNotesRepository() async throws -> ReceivedNoteRepository? {
+        guard let provider = try await prepopulatedDataDbProvider() else { return nil }
         return ReceivedNotesSQLDAO(dbProvider: provider)
     }
         


### PR DESCRIPTION
Closes #469.

- Methods defined in `ZcashRustBackendWelding` protocol which are doing some IO operations are now async.
- `Initializer` no longer have methods to get balance. Only `Synchronizer` now have these methods. These methods are newly async. And `Initilializer` doesn't have alternative APIs.
- There is lot of changes in tests but those are mostly adding `await`. No logic is changed.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.