### PR TITLE
[#901] Use fulfillment instead of wait in async context in tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,7 +1,7 @@
 name: Build and Run Offline Tests
 
 on: 
-  pull_request:
+ pull_request:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/*'
       - '.github/PULL_REQUEST_TEMPLATE.md'
@@ -17,11 +17,13 @@ jobs:
     permissions:
           contents: read
     
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       timeout-minutes: 1
+    - name: Select Xcode version
+      run: sudo xcode-select -s '/Applications/Xcode_14.3.app/Contents/Developer'
     - name: Build ZcashLightClientKit Swift Package
       timeout-minutes: 15
       run: swift build -v

--- a/Tests/AliasDarksideTests/SDKSynchronizerAliasDarksideTests.swift
+++ b/Tests/AliasDarksideTests/SDKSynchronizerAliasDarksideTests.swift
@@ -96,7 +96,7 @@ class SDKSynchronizerAliasDarksideTests: XCTestCase {
             )
         }
 
-        wait(for: expectations, timeout: TimeInterval(aliases.count * 5))
+        await fulfillment(of: expectations, timeout: TimeInterval(aliases.count * 5))
     }
 
     func handleError(_ error: Error?) async {

--- a/Tests/DarksideTests/AdvancedReOrgTests.swift
+++ b/Tests/DarksideTests/AdvancedReOrgTests.swift
@@ -100,7 +100,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
         
-        wait(for: [preTxExpectation], timeout: 10)
+        await fulfillment(of: [preTxExpectation], timeout: 10)
         
         guard shouldContinue else {
             XCTFail("pre receive sync failed")
@@ -134,7 +134,7 @@ class AdvancedReOrgTests: XCTestCase {
         }
 
         sleep(2)
-        wait(for: [receivedTxExpectation], timeout: 10)
+        await fulfillment(of: [receivedTxExpectation], timeout: 10)
         
         guard let syncedSynchronizer = synchronizer else {
             XCTFail("nil synchronizer")
@@ -205,7 +205,7 @@ class AdvancedReOrgTests: XCTestCase {
         8. assert that reorg happened at received_Tx_height
         */
         sleep(2)
-        wait(for: [reorgExpectation, reorgSyncexpectation], timeout: 5, enforceOrder: false)
+        await fulfillment(of: [reorgExpectation, reorgSyncexpectation], timeout: 5, enforceOrder: false)
 
         /*
         9. verify that balance equals initial balance
@@ -237,7 +237,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [finalsyncExpectation], timeout: 5)
+        await fulfillment(of: [finalsyncExpectation], timeout: 5)
         sleep(3)
         
         guard let reorgedTx = await coordinator.synchronizer.receivedTransactions.first else {
@@ -302,7 +302,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [preTxExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation], timeout: 5)
         
         let sendExpectation = XCTestExpectation(description: "sendToAddress")
         var pendingEntity: PendingTransactionEntity?
@@ -326,7 +326,7 @@ class AdvancedReOrgTests: XCTestCase {
             XCTFail("error sending to address. Error: \(String(describing: error))")
         }
         
-        wait(for: [sendExpectation], timeout: 2)
+        await fulfillment(of: [sendExpectation], timeout: 2)
 
         guard let pendingTx = pendingEntity else {
             XCTFail("error sending to address. Error: \(String(describing: testError))")
@@ -374,7 +374,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [sentTxSyncExpectation], timeout: 5)
+        await fulfillment(of: [sentTxSyncExpectation], timeout: 5)
         
         /*
         8. stage sentTx and otherTx at sentTxheight
@@ -411,7 +411,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [afterReOrgExpectation], timeout: 5)
+        await fulfillment(of: [afterReOrgExpectation], timeout: 5)
         
         /*
         12. applyStaged(sentTx + 10)
@@ -434,7 +434,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [lastSyncExpectation], timeout: 5)
+        await fulfillment(of: [lastSyncExpectation], timeout: 5)
 
         let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let expectedPendingTransactionsCount = await coordinator.synchronizer.pendingTransactions.count
@@ -466,7 +466,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 10)
+        await fulfillment(of: [firstSyncExpectation], timeout: 10)
         
         /*
         trigger reorg
@@ -489,7 +489,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [reorgExpectation, afterReorgSync], timeout: 30)
+        await fulfillment(of: [reorgExpectation, afterReorgSync], timeout: 30)
         
         XCTAssertEqual(postReorgVerifiedBalance, preReorgVerifiedBalance)
         XCTAssertEqual(postReorgTotalBalance, preReorgTotalBalance)
@@ -513,7 +513,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [expectation], timeout: 5)
+        await fulfillment(of: [expectation], timeout: 5)
         
         let afterTxHeight = receivedTxHeight + 1
         try coordinator.applyStaged(blockheight: afterTxHeight)
@@ -537,7 +537,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [afterTxSyncExpectation], timeout: 10.0)
+        await fulfillment(of: [afterTxSyncExpectation], timeout: 10.0)
         
         XCTAssertEqual(initialVerifiedBalance, afterTxVerifiedBalance)
         XCTAssertNotEqual(initialBalance, afterTxBalance)
@@ -567,7 +567,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [afterReorgExpectation], timeout: 5)
+        await fulfillment(of: [afterReorgExpectation], timeout: 5)
         
         XCTAssertEqual(afterReOrgBalance, initialBalance)
         XCTAssertEqual(afterReOrgVerifiedBalance, initialVerifiedBalance)
@@ -606,7 +606,7 @@ class AdvancedReOrgTests: XCTestCase {
             }, error: self.handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         /*
         1a. save balances
@@ -654,7 +654,8 @@ class AdvancedReOrgTests: XCTestCase {
                 lastSyncExpectation.fulfill()
             }, error: self.handleError
         )
-        wait(for: [lastSyncExpectation], timeout: 30)
+        await fulfillment(of: [lastSyncExpectation], timeout: 5)
+
         /*
         7. check that balances still match
         */
@@ -662,8 +663,6 @@ class AdvancedReOrgTests: XCTestCase {
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
         XCTAssertEqual(expectedVerifiedBalance, initialVerifiedBalance)
         XCTAssertEqual(expectedBalance, initialBalance)
-        
-
     }
     
     func testTxIndexReorg() async throws {
@@ -687,7 +686,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         try coordinator.resetBlocks(dataset: .predefined(dataset: .txIndexChangeAfter))
         
@@ -703,7 +702,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [lastSyncExpectation], timeout: 5)
+        await fulfillment(of: [lastSyncExpectation], timeout: 5)
 
         let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
@@ -760,7 +759,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         sleep(1)
         let initialTotalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
@@ -784,7 +783,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
         
-        wait(for: [sendExpectation], timeout: 11)
+        await fulfillment(of: [sendExpectation], timeout: 11)
         
         guard pendingEntity != nil else {
             XCTFail("no pending transaction after sending")
@@ -833,7 +832,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [secondSyncExpectation], timeout: 5)
+        await fulfillment(of: [secondSyncExpectation], timeout: 5)
 
         var pendingTransactionsCount = await coordinator.synchronizer.pendingTransactions.count
         XCTAssertEqual(pendingTransactionsCount, 1)
@@ -879,7 +878,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [reorgExpectation, afterReorgExpectation], timeout: 5)
+        await fulfillment(of: [reorgExpectation, afterReorgExpectation], timeout: 5)
         
         /*
         10. verify that there's a pending transaction with -1 mined height
@@ -914,7 +913,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [yetAnotherExpectation], timeout: 5)
+        await fulfillment(of: [yetAnotherExpectation], timeout: 5)
         
         /*
         12. verify that there's a pending transaction with a mined height of sentTxHeight + 2
@@ -952,7 +951,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [thisIsTheLastExpectationIPromess], timeout: 5)
+        await fulfillment(of: [thisIsTheLastExpectationIPromess], timeout: 5)
         
         /*
         15. verify that there's no pending transaction and that the tx is displayed on the sentTransactions collection
@@ -1015,7 +1014,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         let initialBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         let initialVerifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -1040,7 +1039,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [afterReOrgExpectation], timeout: 5)
+        await fulfillment(of: [afterReOrgExpectation], timeout: 5)
         
         guard let afterReOrgTxHeight = await coordinator.synchronizer.receivedTransactions.first?.minedHeight else {
             XCTFail("no incoming transaction found after re org!")
@@ -1088,7 +1087,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         let initialTotalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         let initialVerifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -1108,7 +1107,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [secondSyncExpectation], timeout: 10)
+        await fulfillment(of: [secondSyncExpectation], timeout: 10)
         
         /**
         3. cause reorg
@@ -1126,7 +1125,7 @@ class AdvancedReOrgTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [afterReorgSyncExpectation], timeout: 5)
+        await fulfillment(of: [afterReorgSyncExpectation], timeout: 5)
 
         let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
@@ -1175,7 +1174,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 10)
+        await fulfillment(of: [firstSyncExpectation], timeout: 10)
         
         sleep(1)
         let initialTotalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
@@ -1199,7 +1198,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
         
-        wait(for: [sendExpectation], timeout: 11)
+        await fulfillment(of: [sendExpectation], timeout: 11)
         
         guard pendingEntity != nil else {
             XCTFail("no pending transaction after sending")
@@ -1248,7 +1247,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [secondSyncExpectation], timeout: 5)
+        await fulfillment(of: [secondSyncExpectation], timeout: 5)
         let extraBlocks = 25
         try coordinator.stageBlockCreate(height: sentTxHeight, count: extraBlocks, nonce: 5)
         
@@ -1268,7 +1267,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [reorgExpectation, reorgSyncExpectation], timeout: 5)
+        await fulfillment(of: [reorgExpectation, reorgSyncExpectation], timeout: 5)
         
         guard let pendingTx = await coordinator.synchronizer.pendingTransactions.first else {
             XCTFail("no pending transaction after reorg sync")
@@ -1295,7 +1294,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [lastSyncExpectation], timeout: 5)
+        await fulfillment(of: [lastSyncExpectation], timeout: 5)
 
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
         XCTAssertEqual(expectedBalance, initialTotalBalance)
@@ -1331,7 +1330,7 @@ class AdvancedReOrgTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 600)
+        await fulfillment(of: [firstSyncExpectation], timeout: 600)
         
         let latestScannedHeight = await coordinator.synchronizer.latestBlocksDataProvider.latestScannedHeight
         XCTAssertEqual(latestScannedHeight, birthday + fullSyncLength)

--- a/Tests/DarksideTests/BalanceTests.swift
+++ b/Tests/DarksideTests/BalanceTests.swift
@@ -71,7 +71,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         // 2 check that there are no unconfirmed funds
         
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -99,7 +99,7 @@ class BalanceTests: XCTestCase {
             XCTFail("sendToAddress failed: \(error)")
         }
 
-        wait(for: [sentTransactionExpectation], timeout: 20)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 20)
         guard let pendingTx else {
             XCTFail("transaction creation failed")
             return
@@ -151,7 +151,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
         
         // 7 advance to confirmation
         
@@ -178,7 +178,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [confirmExpectation], timeout: 5)
+        await fulfillment(of: [confirmExpectation], timeout: 5)
         
         let confirmedPending = try await coordinator.synchronizer.allPendingTransactions()
             .first(where: { $0.rawTransactionId == pendingTx.rawTransactionId })
@@ -221,7 +221,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         // 2 check that there are no unconfirmed funds
         
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -248,7 +248,7 @@ class BalanceTests: XCTestCase {
             XCTFail("sendToAddress failed: \(error)")
         }
 
-        wait(for: [sentTransactionExpectation], timeout: 20)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 20)
         guard let pendingTx else {
             XCTFail("transaction creation failed")
             return
@@ -300,7 +300,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
         
         // 7 advance to confirmation
         
@@ -327,7 +327,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
         
-        wait(for: [confirmExpectation], timeout: 5)
+        await fulfillment(of: [confirmExpectation], timeout: 5)
         
         let confirmedPending = try await coordinator.synchronizer
             .allPendingTransactions()
@@ -371,7 +371,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         // 2 check that there are no unconfirmed funds
         
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -398,7 +398,7 @@ class BalanceTests: XCTestCase {
             XCTFail("sendToAddress failed: \(error)")
         }
 
-        wait(for: [sentTransactionExpectation], timeout: 20)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 20)
         guard let pendingTx else {
             XCTFail("transaction creation failed")
             return
@@ -450,7 +450,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
         
         // 7 advance to confirmation
         
@@ -477,7 +477,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
         
-        wait(for: [confirmExpectation], timeout: 5)
+        await fulfillment(of: [confirmExpectation], timeout: 5)
         
         let confirmedPending = try await coordinator.synchronizer
             .allPendingTransactions()
@@ -526,7 +526,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [syncedExpectation], timeout: 60)
+        await fulfillment(of: [syncedExpectation], timeout: 60)
         
         let spendingKey = coordinator.spendingKey
         
@@ -556,7 +556,7 @@ class BalanceTests: XCTestCase {
 
         var expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         XCTAssertTrue(expectedVerifiedBalance > .zero)
-        wait(for: [sentTransactionExpectation], timeout: 12)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 12)
         
         // sync and mine
         
@@ -585,7 +585,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation], timeout: 5)
 
         expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
@@ -701,7 +701,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
         
-        wait(for: [syncedExpectation], timeout: 5)
+        await fulfillment(of: [syncedExpectation], timeout: 5)
         
         let spendingKey = coordinator.spendingKey
 
@@ -729,7 +729,7 @@ class BalanceTests: XCTestCase {
 
         var expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         XCTAssertTrue(expectedVerifiedBalance > .zero)
-        wait(for: [sentTransactionExpectation], timeout: 12)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 12)
 
         expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         if let testError {
@@ -776,7 +776,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation], timeout: 5)
 
         expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
         XCTAssertEqual(
@@ -812,7 +812,7 @@ class BalanceTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [syncedExpectation], timeout: 5)
+        await fulfillment(of: [syncedExpectation], timeout: 5)
 
         let clearedTransactions = await coordinator.synchronizer.clearedTransactions
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()
@@ -867,7 +867,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [syncedExpectation], timeout: 6)
+        await fulfillment(of: [syncedExpectation], timeout: 6)
         
         let previousVerifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let previousTotalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
@@ -891,7 +891,7 @@ class BalanceTests: XCTestCase {
         } catch {
             XCTFail("error sending \(error)")
         }
-        wait(for: [createToAddressExpectation], timeout: 30)
+        await fulfillment(of: [createToAddressExpectation], timeout: 30)
         
         let syncToMinedheightExpectation = XCTestExpectation(description: "sync to mined height + 1")
         
@@ -997,7 +997,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
         
-        wait(for: [syncToMinedheightExpectation], timeout: 5)
+        await fulfillment(of: [syncToMinedheightExpectation], timeout: 5)
     }
     
     /**
@@ -1039,7 +1039,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [syncedExpectation], timeout: 5)
+        await fulfillment(of: [syncedExpectation], timeout: 5)
         
         let spendingKey = coordinator.spendingKey
         
@@ -1065,7 +1065,7 @@ class BalanceTests: XCTestCase {
             XCTFail("sendToAddress failed: \(error)")
         }
 
-        wait(for: [sendExpectation], timeout: 12)
+        await fulfillment(of: [sendExpectation], timeout: 12)
         
         guard let pendingTransaction = pendingTx, pendingTransaction.expiryHeight > defaultLatestHeight else {
             XCTFail("No pending transaction")
@@ -1089,7 +1089,7 @@ class BalanceTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [expirationSyncExpectation], timeout: 5)
+        await fulfillment(of: [expirationSyncExpectation], timeout: 5)
 
         let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let expectedBalance = try await coordinator.synchronizer.getShieldedBalance()

--- a/Tests/DarksideTests/DarksideSanityCheckTests.swift
+++ b/Tests/DarksideTests/DarksideSanityCheckTests.swift
@@ -68,7 +68,7 @@ class DarksideSanityCheckTests: XCTestCase {
             }
         )
         
-        wait(for: [syncExpectation], timeout: 5)
+        await fulfillment(of: [syncExpectation], timeout: 5)
         
         let blocksDao = BlockSQLDAO(dbProvider: SimpleConnectionProvider(path: coordinator.databases.dataDB.absoluteString, readonly: false))
         

--- a/Tests/DarksideTests/InternalStateConsistencyTests.swift
+++ b/Tests/DarksideTests/InternalStateConsistencyTests.swift
@@ -74,7 +74,7 @@ final class InternalStateConsistencyTests: XCTestCase {
             }
         }
 
-        wait(for: [firstSyncExpectation], timeout: 2)
+        await fulfillment(of: [firstSyncExpectation], timeout: 2)
 
         let isSyncing = await coordinator.synchronizer.status.isSyncing
         let status = await coordinator.synchronizer.status
@@ -131,7 +131,7 @@ final class InternalStateConsistencyTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [secondSyncAttemptExpectation], timeout: 10)
+        await fulfillment(of: [secondSyncAttemptExpectation], timeout: 10)
     }
 
     func handleError(_ error: Error?) {

--- a/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
+++ b/Tests/DarksideTests/PendingTransactionUpdatesTest.swift
@@ -67,7 +67,7 @@ class PendingTransactionUpdatesTest: XCTestCase {
         } catch {
             await handleError(error)
         }
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         sleep(1)
         
@@ -91,7 +91,7 @@ class PendingTransactionUpdatesTest: XCTestCase {
             await self.handleError(error)
         }
         
-        wait(for: [sendExpectation], timeout: 11)
+        await fulfillment(of: [sendExpectation], timeout: 11)
         
         guard let pendingUnconfirmedTx = pendingEntity else {
             XCTFail("no pending transaction after sending")
@@ -158,7 +158,7 @@ class PendingTransactionUpdatesTest: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [secondSyncExpectation], timeout: 5)
+        await fulfillment(of: [secondSyncExpectation], timeout: 5)
 
         let pendingTransactionsCount = await coordinator.synchronizer.pendingTransactions.count
         XCTAssertEqual(pendingTransactionsCount, 1)
@@ -203,7 +203,7 @@ class PendingTransactionUpdatesTest: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [syncToConfirmExpectation], timeout: 6)
+        await fulfillment(of: [syncToConfirmExpectation], timeout: 6)
         let supposedlyPendingUnexistingTransaction = try await coordinator.synchronizer.allPendingTransactions().first
 
         let clearedTransactions = await coordinator.synchronizer

--- a/Tests/DarksideTests/ReOrgTests.swift
+++ b/Tests/DarksideTests/ReOrgTests.swift
@@ -148,7 +148,7 @@ class ReOrgTests: XCTestCase {
             error: self.handleError
         )
        
-        wait(for: [firstSyncExpectation], timeout: 5)
+        await fulfillment(of: [firstSyncExpectation], timeout: 5)
         
         guard let syncedSynchronizer = synchronizer else {
             XCTFail("nil synchronizer")
@@ -190,7 +190,7 @@ class ReOrgTests: XCTestCase {
         
         // now reorg should happen and reorg notifications and idle notification should be triggered
         
-        wait(for: [reorgExpectation, secondSyncExpectation], timeout: 5)
+        await fulfillment(of: [reorgExpectation, secondSyncExpectation], timeout: 5)
         
         // now everything should be fine. latest block should be targetHeight
 

--- a/Tests/DarksideTests/RewindRescanTests.swift
+++ b/Tests/DarksideTests/RewindRescanTests.swift
@@ -76,7 +76,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let totalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         // 2 check that there are no unconfirmed funds
@@ -105,7 +105,7 @@ class RewindRescanTests: XCTestCase {
                 .store(in: &cancellables)
         }
 
-        wait(for: [rewindExpectation], timeout: 2)
+        await fulfillment(of: [rewindExpectation], timeout: 2)
 
         // assert that after the new height is
         let lastScannedHeight = try await coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight()
@@ -129,7 +129,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [secondScanExpectation], timeout: 12)
+        await fulfillment(of: [secondScanExpectation], timeout: 12)
         
         // verify that the balance still adds up
         expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -164,7 +164,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 20)
+        await fulfillment(of: [firstSyncExpectation], timeout: 20)
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let totalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         // 2 check that there are no unconfirmed funds
@@ -202,7 +202,7 @@ class RewindRescanTests: XCTestCase {
                 .store(in: &cancellables)
         }
 
-        wait(for: [rewindExpectation], timeout: 2)
+        await fulfillment(of: [rewindExpectation], timeout: 2)
 
         // check that the balance is cleared
         var expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -221,7 +221,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [secondScanExpectation], timeout: 20)
+        await fulfillment(of: [secondScanExpectation], timeout: 20)
         
         // verify that the balance still adds up
         expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -243,7 +243,7 @@ class RewindRescanTests: XCTestCase {
         } catch {
             XCTFail("sending fail: \(error)")
         }
-        wait(for: [sendExpectation], timeout: 15)
+        await fulfillment(of: [sendExpectation], timeout: 15)
     }
 
     // FIX [#790]: Fix tests
@@ -263,7 +263,7 @@ class RewindRescanTests: XCTestCase {
             error: handleError
         )
         
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let totalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
         // 2 check that there are no unconfirmed funds
@@ -297,7 +297,7 @@ class RewindRescanTests: XCTestCase {
                 .store(in: &cancellables)
         }
 
-        wait(for: [rewindExpectation], timeout: 2)
+        await fulfillment(of: [rewindExpectation], timeout: 2)
 
         // assert that after the new height is lower or same as transaction, rewind doesn't have to be make exactly to transaction height, it can
         // be done to nearest height provided by rust
@@ -313,7 +313,7 @@ class RewindRescanTests: XCTestCase {
             error: handleError
         )
         
-        wait(for: [secondScanExpectation], timeout: 12)
+        await fulfillment(of: [secondScanExpectation], timeout: 12)
         
         // verify that the balance still adds up
         let expectedVerifiedBalance = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -349,7 +349,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
         // 2 check that there are no unconfirmed funds
         
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
@@ -375,7 +375,7 @@ class RewindRescanTests: XCTestCase {
         } catch {
             XCTFail("sendToAddress failed: \(error)")
         }
-        wait(for: [sentTransactionExpectation], timeout: 20)
+        await fulfillment(of: [sentTransactionExpectation], timeout: 20)
         guard let pendingTx else {
             XCTFail("transaction creation failed")
             return
@@ -428,7 +428,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [mineExpectation, transactionMinedExpectation, foundTransactionsExpectation], timeout: 5)
         
         // 7 advance to confirmation
         
@@ -458,7 +458,7 @@ class RewindRescanTests: XCTestCase {
                 .store(in: &cancellables)
         }
 
-        wait(for: [rewindExpectation], timeout: 2)
+        await fulfillment(of: [rewindExpectation], timeout: 2)
 
         guard
             let pendingEntity = try await coordinator.synchronizer.allPendingTransactions()
@@ -495,7 +495,7 @@ class RewindRescanTests: XCTestCase {
             handleError(error)
         }
 
-        wait(for: [confirmExpectation], timeout: 10)
+        await fulfillment(of: [confirmExpectation], timeout: 10)
         
         let confirmedPending = try await coordinator.synchronizer.allPendingTransactions()
             .first(where: { $0.rawTransactionId == pendingTx.rawTransactionId })

--- a/Tests/DarksideTests/ShieldFundsTests.swift
+++ b/Tests/DarksideTests/ShieldFundsTests.swift
@@ -122,7 +122,7 @@ class ShieldFundsTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [preTxExpectation], timeout: 10)
+        await fulfillment(of: [preTxExpectation], timeout: 10)
 
         guard shouldContinue else {
             XCTFail("pre receive sync failed")
@@ -162,7 +162,7 @@ class ShieldFundsTests: XCTestCase {
         } catch {
             await handleError(error)
         }
-        wait(for: [tFundsDetectionExpectation], timeout: 2)
+        await fulfillment(of: [tFundsDetectionExpectation], timeout: 2)
 
         // at this point the balance should be zero for shielded, then zero verified transparent funds
         // and 10000 zatoshi of total (not verified) transparent funds.
@@ -193,7 +193,7 @@ class ShieldFundsTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [tFundsConfirmationSyncExpectation], timeout: 5)
+        await fulfillment(of: [tFundsConfirmationSyncExpectation], timeout: 5)
 
         // the transparent funds should be 10000 zatoshis both total and verified
         let confirmedTFundsBalance = try await coordinator.synchronizer.getTransparentBalance(accountIndex: 0)
@@ -224,7 +224,7 @@ class ShieldFundsTests: XCTestCase {
             XCTFail("Failed With error: \(error.localizedDescription)")
         }
 
-        wait(for: [shieldFundsExpectation], timeout: 30)
+        await fulfillment(of: [shieldFundsExpectation], timeout: 30)
 
         guard shouldContinue else { return }
 
@@ -277,7 +277,7 @@ class ShieldFundsTests: XCTestCase {
             postShieldSyncExpectation.fulfill()
         }
 
-        wait(for: [postShieldSyncExpectation], timeout: 3)
+        await fulfillment(of: [postShieldSyncExpectation], timeout: 3)
 
         guard shouldContinue else { return }
 
@@ -315,7 +315,7 @@ class ShieldFundsTests: XCTestCase {
             confirmationExpectation.fulfill()
         }
 
-        wait(for: [confirmationExpectation], timeout: 5)
+        await fulfillment(of: [confirmationExpectation], timeout: 5)
 
         guard shouldContinue else { return }
 

--- a/Tests/DarksideTests/SynchronizerDarksideTests.swift
+++ b/Tests/DarksideTests/SynchronizerDarksideTests.swift
@@ -73,7 +73,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [preTxExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation], timeout: 5)
         
         XCTAssertEqual(self.foundTransactions.count, 2)
     }
@@ -104,7 +104,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [firsTxExpectation], timeout: 10)
+        await fulfillment(of: [firsTxExpectation], timeout: 10)
         
         XCTAssertEqual(self.foundTransactions.count, 5)
         
@@ -122,7 +122,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [preTxExpectation], timeout: 10)
+        await fulfillment(of: [preTxExpectation], timeout: 10)
         
         XCTAssertTrue(self.foundTransactions.isEmpty)
         
@@ -138,7 +138,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
         
-        wait(for: [findManyTxExpectation], timeout: 10)
+        await fulfillment(of: [findManyTxExpectation], timeout: 10)
         
         XCTAssertEqual(self.foundTransactions.count, 2)
     }
@@ -172,7 +172,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
 
-        wait(for: [preTxExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation], timeout: 5)
 
         let expectedStates: [SynchronizerState] = [
             SynchronizerState(
@@ -328,7 +328,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
 
-        wait(for: [preTxExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation], timeout: 5)
 
         let expectedStates: [SynchronizerState] = [
             SynchronizerState(
@@ -468,7 +468,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
 
-        wait(for: [secondSyncExpectation], timeout: 5)
+        await fulfillment(of: [secondSyncExpectation], timeout: 5)
 
         let secondBatchOfExpectedStates: [SynchronizerState] = [
             SynchronizerState(
@@ -539,7 +539,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
 
-        wait(for: [firsSyncExpectation], timeout: 10)
+        await fulfillment(of: [firsSyncExpectation], timeout: 10)
 
         let wipeFinished = XCTestExpectation(description: "SynchronizerWipeFinished Expectation")
 
@@ -560,7 +560,7 @@ class SynchronizerDarksideTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [wipeFinished], timeout: 1)
+        await fulfillment(of: [wipeFinished], timeout: 1)
 
         _ = try await coordinator.prepare(seed: Environment.seedBytes)
 
@@ -573,7 +573,7 @@ class SynchronizerDarksideTests: XCTestCase {
             error: self.handleError
         )
 
-        wait(for: [secondSyncExpectation], timeout: 10)
+        await fulfillment(of: [secondSyncExpectation], timeout: 10)
     }
     
     func handleFoundTransactions(transactions: [ZcashTransaction.Overview]) {

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -94,7 +94,7 @@ final class SynchronizerTests: XCTestCase {
         try await Task.sleep(nanoseconds: 5_000_000_000)
         await self.coordinator.synchronizer.stop()
 
-        wait(for: [syncStoppedExpectation], timeout: 6)
+        await fulfillment(of: [syncStoppedExpectation], timeout: 6)
 
         let status = await coordinator.synchronizer.status
         XCTAssertEqual(status, .stopped)
@@ -128,7 +128,7 @@ final class SynchronizerTests: XCTestCase {
             error: handleError
         )
 
-        wait(for: [syncFinished], timeout: 3)
+        await fulfillment(of: [syncFinished], timeout: 3)
 
         let wipeFinished = XCTestExpectation(description: "SynchronizerWipeFinished Expectation")
 
@@ -152,7 +152,7 @@ final class SynchronizerTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [wipeFinished], timeout: 1)
+        await fulfillment(of: [wipeFinished], timeout: 1)
 
         /*
          Check that wipe cleared everything that is expected
@@ -209,7 +209,7 @@ final class SynchronizerTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [wipeFinished], timeout: 6)
+        await fulfillment(of: [wipeFinished], timeout: 6)
 
         /*
          Check that wipe cleared everything that is expected
@@ -279,7 +279,7 @@ final class SynchronizerTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [firstSyncExpectation], timeout: 12)
+        await fulfillment(of: [firstSyncExpectation], timeout: 12)
 
         // Add more blocks to the chain so the long sync can start.
         try FakeChainBuilder.buildChain(darksideWallet: coordinator.service, branchID: branchID, chainName: chainName, length: 10000)
@@ -303,7 +303,7 @@ final class SynchronizerTests: XCTestCase {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 1)
+        await fulfillment(of: [waitExpectation], timeout: 1)
 
         let verifiedBalance: Zatoshi = try await coordinator.synchronizer.getShieldedVerifiedBalance()
         let totalBalance: Zatoshi = try await coordinator.synchronizer.getShieldedBalance()
@@ -330,7 +330,7 @@ final class SynchronizerTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [rewindExpectation], timeout: 5)
+        await fulfillment(of: [rewindExpectation], timeout: 5)
 
         // assert that after the new height is
         let lastScannedHeight = try await coordinator.synchronizer.initializer.transactionRepository.lastScannedHeight()

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -217,8 +217,8 @@ class TransactionEnhancementTests: XCTestCase {
             XCTFail("Error: \(error)")
         }
 
-        wait(
-            for: [
+        await fulfillment(
+            of: [
                 syncStartedExpect,
                 txFoundNotificationExpectation,
                 finishedNotificationExpectation

--- a/Tests/DarksideTests/Z2TReceiveTests.swift
+++ b/Tests/DarksideTests/Z2TReceiveTests.swift
@@ -80,7 +80,7 @@ class Z2TReceiveTests: XCTestCase {
         } catch {
             await handleError(error)
         }
-        wait(for: [preTxExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation, foundTransactionsExpectation], timeout: 5)
         
         let sendExpectation = XCTestExpectation(description: "sendToAddress")
         let sendAmount = Zatoshi(10000)
@@ -132,7 +132,7 @@ class Z2TReceiveTests: XCTestCase {
         } catch {
             await handleError(error)
         }
-        wait(for: [preTxExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [preTxExpectation, foundTransactionsExpectation], timeout: 5)
 
         let sendExpectation = XCTestExpectation(description: "sendToAddress")
         var pendingEntity: PendingTransactionEntity?
@@ -154,7 +154,7 @@ class Z2TReceiveTests: XCTestCase {
             testError = error
         }
 
-        wait(for: [sendExpectation], timeout: 12)
+        await fulfillment(of: [sendExpectation], timeout: 12)
 
         guard pendingEntity != nil else {
             XCTFail("error sending to address. Error: \(String(describing: testError))")
@@ -205,7 +205,7 @@ class Z2TReceiveTests: XCTestCase {
             await handleError(error)
         }
 
-        wait(for: [sentTxSyncExpectation, foundTransactionsExpectation], timeout: 5)
+        await fulfillment(of: [sentTxSyncExpectation, foundTransactionsExpectation], timeout: 5)
     }
 
     func handleError(_ error: Error?) async {

--- a/Tests/NetworkTests/CompactBlockProcessorTests.swift
+++ b/Tests/NetworkTests/CompactBlockProcessorTests.swift
@@ -167,8 +167,8 @@ class CompactBlockProcessorTests: XCTestCase {
     func testStartNotifiesSuscriptors() async {
         await startProcessing()
    
-        wait(
-            for: [
+        await fulfillment(
+            of: [
                 syncStartedExpect,
                 finishedNotificationExpectation
             ],
@@ -186,7 +186,7 @@ class CompactBlockProcessorTests: XCTestCase {
         updatedNotificationExpectation.expectedFulfillmentCount = expectedUpdates
         
         await startProcessing()
-        wait(for: [updatedNotificationExpectation, finishedNotificationExpectation], timeout: 300)
+        await fulfillment(of: [updatedNotificationExpectation, finishedNotificationExpectation], timeout: 300)
     }
     
     private func expectedBatches(currentHeight: BlockHeight, targetHeight: BlockHeight, batchSize: Int) -> Int {

--- a/Tests/NetworkTests/CompactBlockReorgTests.swift
+++ b/Tests/NetworkTests/CompactBlockReorgTests.swift
@@ -188,8 +188,8 @@ class CompactBlockReorgTests: XCTestCase {
     func testNotifiesReorg() async {
         await startProcessing()
 
-        wait(
-            for: [
+        await fulfillment(
+            of: [
                 syncStartedExpect,
                 reorgNotificationExpectation,
                 finishedNotificationExpectation

--- a/Tests/NetworkTests/LightWalletServiceTests.swift
+++ b/Tests/NetworkTests/LightWalletServiceTests.swift
@@ -37,7 +37,7 @@ class LightWalletServiceTests: XCTestCase {
 //            expect.fulfill()
 //
 //        }
-//        wait(for: [expect], timeout: 20)
+//        await fulfillment(of: [expect], timeout: 20)
 //    }
     
     func testHundredBlocks() async throws {

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -103,7 +103,7 @@ class SynchronizerOfflineTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [firstWipeExpectation], timeout: 1)
+        await fulfillment(of: [firstWipeExpectation], timeout: 1)
 
         let secondWipeExpectation = XCTestExpectation(description: "Second wipe expectation")
 
@@ -125,7 +125,7 @@ class SynchronizerOfflineTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [secondWipeExpectation], timeout: 1)
+        await fulfillment(of: [secondWipeExpectation], timeout: 1)
     }
 
     func testPrepareCanBeCalledAfterWipeWithSameInstanceOfSDKSynchronizer() async throws {
@@ -147,7 +147,7 @@ class SynchronizerOfflineTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
 
         do {
             _ = try await testCoordinator.prepare(seed: Environment.seedBytes)
@@ -230,7 +230,7 @@ class SynchronizerOfflineTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     func testURLsParsingFailsInInitialierPrepareThenThrowsError() async throws {
@@ -317,7 +317,7 @@ class SynchronizerOfflineTests: XCTestCase {
             )
             .store(in: &cancellables)
 
-        wait(for: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     func testIsNewSessionOnUnpreparedToValidTransition() {

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -108,7 +108,7 @@ class SynchronizerTests: XCTestCase {
             
             try await synchronizer.start()
             
-            wait(for: [syncSyncedExpectation], timeout: 100)
+            await fulfillment(of: [syncSyncedExpectation], timeout: 100)
             
             synchronizer.metrics.cumulateReportsAndStartNewSet()
         }


### PR DESCRIPTION
Closes #901

- Swift 5.8 throws warning when `wait` is used in async context. And it suggests to use `fulfillment`. It works fine. And `fulfillment` is available from Xcode 11. So there is not problem with backwards compatibility.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [ ] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.