### PR TITLE
Add Sync Session ID Synchronizer State

### DIFF
--- a/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
@@ -1108,8 +1108,8 @@ actor CompactBlockProcessor {
             timeInterval: interval,
             repeats: true,
             block: { [weak self] _ in
-                Task { [self] in
-                    guard let self = self else { return }
+                Task { [weak self] in
+                    guard let self else { return }
                     if await self.shouldStart {
                         self.logger.debug(
                             """

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -64,15 +64,27 @@ public enum ConnectionState {
     /// the connection has been closed
     case shutdown
 }
-
+/// Reports the state of a synchronizer.
 public struct SynchronizerState: Equatable {
+    /// Unique Identifier for the current sync attempt
+    /// - Note: Although on it's lifetime a synchronizer will attempt to sync between random fractions of a minute (when idle),
+    /// each sync attempt will be considered a new sync session. This is to maintain a consistent UUID cadence
+    /// given how application lifecycle varies between OS Versions, platforms, etc.
+    /// SyncSessionIDs are provided to users
+    public var syncSessionID: UUID
+    /// shielded balance known to this synchronizer given the data that has processed locally
     public var shieldedBalance: WalletBalance
+    /// transparent balance known to this synchronizer given the data that has processed locally
     public var transparentBalance: WalletBalance
+    /// status of the whole sync process
     public var syncStatus: SyncStatus
+    /// height of the latest scanned block known to this synchronizer.
     public var latestScannedHeight: BlockHeight
 
+    /// Represents a synchronizer that has made zero progress hasn't done a sync attempt
     public static var zero: SynchronizerState {
         SynchronizerState(
+            syncSessionID: .nullID,
             shieldedBalance: .zero,
             transparentBalance: .zero,
             syncStatus: .unprepared,
@@ -421,5 +433,12 @@ extension SyncStatus {
         case .fetch:
             self = .fetching
         }
+    }
+}
+
+extension UUID {
+    /// UUID  00000000-0000-0000-0000-000000000000
+    static var nullID: UUID {
+        UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
     }
 }

--- a/Sources/ZcashLightClientKit/Utils/SyncSessionIDGenerator.swift
+++ b/Sources/ZcashLightClientKit/Utils/SyncSessionIDGenerator.swift
@@ -1,0 +1,33 @@
+//
+//  File.swift
+//  
+//
+//  Created by Francisco Gindre on 3/31/23.
+//
+
+import Foundation
+
+
+protocol SyncSessionIDGenerator {
+    func nextID() -> UUID
+}
+
+struct UniqueSyncSessionIDGenerator {}
+
+extension UniqueSyncSessionIDGenerator: SyncSessionIDGenerator {
+    func nextID() -> UUID {
+        UUID()
+    }
+}
+
+typealias SyncSession = GenericActor<UUID>
+
+extension SyncSession {
+    /// updates the current sync session to a new value with the given generator
+    /// - Parameters generator: a `SyncSessionIDGenerator`
+    /// - returns: the `UUID` of the newly updated value.
+    @discardableResult
+    func newSession(with generator: SyncSessionIDGenerator) async -> UUID {
+        return await self.update(generator.nextID())
+    }
+}

--- a/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
@@ -40,6 +40,7 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
 
     func testStateStreamEmitsAsExpected() {
         let state = SynchronizerState(
+            syncSessionID: .nullID,
             shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
             transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
             syncStatus: .fetching,
@@ -70,6 +71,7 @@ class ClosureSynchronizerOfflineTests: XCTestCase {
 
     func testLatestStateIsAsExpected() {
         let state = SynchronizerState(
+            syncSessionID: .nullID,
             shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
             transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
             syncStatus: .fetching,

--- a/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/CombineSynchronizerOfflineTests.swift
@@ -38,6 +38,7 @@ class CombineSynchronizerOfflineTests: XCTestCase {
 
     func testStateStreamEmitsAsExpected() {
         let state = SynchronizerState(
+            syncSessionID: .nullID,
             shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
             transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
             syncStatus: .fetching,
@@ -68,6 +69,7 @@ class CombineSynchronizerOfflineTests: XCTestCase {
 
     func testLatestStateIsAsExpected() {
         let state = SynchronizerState(
+            syncSessionID: .nullID,
             shieldedBalance: WalletBalance(verified: Zatoshi(100), total: Zatoshi(200)),
             transparentBalance: WalletBalance(verified: Zatoshi(200), total: Zatoshi(300)),
             syncStatus: .fetching,

--- a/Tests/TestUtils/MockSessionIDGenerator.swift
+++ b/Tests/TestUtils/MockSessionIDGenerator.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by Francisco Gindre on 3/31/23.
+//
+
+import Foundation
+@testable import ZcashLightClientKit
+
+/// This generator will consume the list of UUID passed and fail if empty.
+class MockSyncSessionIDGenerator: SyncSessionIDGenerator {
+    var ids: [UUID]
+
+    init(ids: [UUID]) {
+        self.ids = ids
+    }
+
+    func nextID() -> UUID {
+        ids.removeFirst()
+    }
+}

--- a/Tests/TestUtils/SDKSynchronizer+Utils.swift
+++ b/Tests/TestUtils/SDKSynchronizer+Utils.swift
@@ -1,0 +1,31 @@
+//
+//  File.swift
+//  
+//
+//  Created by Francisco Gindre on 3/31/23.
+//
+
+import Foundation
+@testable import ZcashLightClientKit
+
+extension SDKSynchronizer {
+    convenience init(initializer: Initializer, sessionGenerator: SyncSessionIDGenerator, sessionTicker: SessionTicker) {
+        let metrics = SDKMetrics()
+        self.init(
+            status: .unprepared,
+            initializer: initializer,
+            transactionManager: OutboundTransactionManagerBuilder.build(initializer: initializer),
+            transactionRepository: initializer.transactionRepository,
+            utxoRepository: UTXORepositoryBuilder.build(initializer: initializer),
+            blockProcessor: CompactBlockProcessor(
+                initializer: initializer,
+                metrics: metrics,
+                logger: initializer.logger,
+                walletBirthdayProvider: { initializer.walletBirthday }
+            ),
+            metrics: metrics,
+            syncSessionIDGenerator: sessionGenerator,
+            syncSessionTicker: sessionTicker
+        )
+    }
+}

--- a/Tests/TestUtils/TestCoordinator.swift
+++ b/Tests/TestUtils/TestCoordinator.swift
@@ -58,7 +58,8 @@ class TestCoordinator {
         walletBirthday: BlockHeight,
         network: ZcashNetwork,
         callPrepareInConstructor: Bool = true,
-        endpoint: LightWalletEndpoint = TestCoordinator.defaultEndpoint
+        endpoint: LightWalletEndpoint = TestCoordinator.defaultEndpoint,
+        syncSessionIDGenerator: SyncSessionIDGenerator = UniqueSyncSessionIDGenerator()
     ) async throws {
         let derivationTool = DerivationTool(networkType: network.networkType)
 
@@ -76,7 +77,8 @@ class TestCoordinator {
             walletBirthday: walletBirthday,
             network: network,
             callPrepareInConstructor: callPrepareInConstructor,
-            endpoint: endpoint
+            endpoint: endpoint,
+            syncSessionIDGenerator: syncSessionIDGenerator
         )
     }
     
@@ -87,7 +89,8 @@ class TestCoordinator {
         walletBirthday: BlockHeight,
         network: ZcashNetwork,
         callPrepareInConstructor: Bool = true,
-        endpoint: LightWalletEndpoint = TestCoordinator.defaultEndpoint
+        endpoint: LightWalletEndpoint = TestCoordinator.defaultEndpoint,
+        syncSessionIDGenerator: SyncSessionIDGenerator
     ) async throws {
         await InternalSyncProgress(alias: alias, storage: UserDefaults.standard, logger: logger).rewind(to: 0)
 
@@ -114,7 +117,7 @@ class TestCoordinator {
             logLevel: .debug
         )
 
-        let synchronizer = SDKSynchronizer(initializer: initializer)
+        let synchronizer = SDKSynchronizer(initializer: initializer, sessionGenerator: syncSessionIDGenerator, sessionTicker: .live)
         
         self.synchronizer = synchronizer
         subscribeToState(synchronizer: self.synchronizer)


### PR DESCRIPTION
Closes #895 

Add Sync Session ID to `SynchronizerState`.

A SyncSession is an attempt to sync the blockchain within the lifetime of a Synchronizer.
A Synchronizer can sync many times, when synced it will refresh every ~20 seconds +- random padding.
each sync attempt will have a different UUID even if it's from the same instance of SDKSynchronizer.

**How are SyncSessions are delimited? With `SyncStatus` changes.** 

changes from [`.unprepared`|`.error`|`.disconnected`|`.stopped`] to `.syncing` assign a new sessionID to the synchronizer.

Any other transitions won't. 

`areTwoStatusesDifferent ` was refactored to a helper function of `SyncStatus`


**How are IDs generated?**

ID generation is not mandated but delegated to a protocol `SyncSessionIDGenerator`.
Tests inject their own deterministic generator to avoid test flakiness.

Default implementation of SyncSessionIDGenerator is 

````Swift
struct UniqueSyncSessionIDGenerator {}

extension UniqueSyncSessionIDGenerator: SyncSessionIDGenerator {
    func nextID() -> UUID {
        UUID()
    }
}
````

**SyncSession Pseudo-Atomicity and thread safety** 

SyncSession is a type alias of a GenericActor holding a UUID

````
typealias SyncSession = GenericActor<UUID>

extension SyncSession {
    /// updates the current sync session to a new value with the given generator
    /// - Parameters generator: a `SyncSessionIDGenerator`
    /// - returns: the `UUID` of the newly updated value.
    @discardableResult
    func newSession(with generator: SyncSessionIDGenerator) async -> UUID {
        return await self.update(generator.nextID())
    }
}
````
This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.