### PR TITLE
[#361] Introduce ZcashError

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,8 @@ excluded:
   - build/
   - docs/
   - Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+  - Sources/ZcashLightClientKit/Error/ZcashError.swift
+  - Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
 
 disabled_rules:
   - notification_center_detachment

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
             ],
             exclude: [
                 "Modules/Service/GRPC/ProtoBuf/proto/compact_formats.proto",
-                "Modules/Service/GRPC/ProtoBuf/proto/service.proto"
+                "Modules/Service/GRPC/ProtoBuf/proto/service.proto",
+                "Error/Sourcery/"
             ],
             resources: [
                 .copy("Resources/checkpoints")

--- a/Sources/ZcashLightClientKit/Error/Sourcery/ZcashError.stencil
+++ b/Sources/ZcashLightClientKit/Error/Sourcery/ZcashError.stencil
@@ -1,0 +1,38 @@
+/*
+!!!!! To edit this file go to ZcashErrorCodeDefinition first and udate/add codes. Then run generateErrorCode.sh script to regenerate this file.
+
+By design each error should be used only at one place in the app. Thanks to that it is possible to identify exact line in the code from which the
+error originates. And it can help with debugging.
+*/
+
+{% for type in types.enums where type.name == "ZcashErrorDefinition" %}
+public enum ZcashError: Equatable, Error {
+    {% for case in type.cases %}
+    {% for docLine in case.documentation %}
+    /// {{ docLine }}
+    {% endfor %}
+    /// {{ case.annotations["code"] }}
+    case {{ case.name }}{% if case.associatedValues.count > 0 %}({% for value in case.associatedValues %}_ {{ value.externalName }}: {{ value.typeName }}{% if not forloop.last%}, {% endif %}{% endfor %}){% endif %}
+    {% endfor %}
+
+    public var message: String {
+        switch self {
+        {% for case in type.cases %}
+        case .{{ case.name }}: return "{{ case.documentation[0] }}"
+        {% endfor %}
+        }
+    }
+
+    public var code: ZcashErrorCode {
+        switch self {
+            {% for case in type.cases %}
+        case .{{ case.name }}: return .{{ case.name}}
+            {% endfor %}
+        }
+    }
+
+    public static func == (lhs: ZcashError, rhs: ZcashError) -> Bool {
+        return lhs.code == rhs.code
+    }
+}
+{% endfor %}

--- a/Sources/ZcashLightClientKit/Error/Sourcery/ZcashErrorCode.stencil
+++ b/Sources/ZcashLightClientKit/Error/Sourcery/ZcashErrorCode.stencil
@@ -1,0 +1,17 @@
+/*
+!!!!! To edit this file go to ZcashErrorCodeDefinition first and udate/add codes. Then run generateErrorCode.sh script to regenerate this file.
+
+By design each error code should be used only at one place in the app. Thanks to that it is possible to identify exact line in the code from which the
+error originates. And it can help with debugging.
+*/
+
+{% for type in types.enums where type.name == "ZcashErrorDefinition" %}
+public enum ZcashErrorCode: String {
+    {% for case in type.cases %}
+    {% for docLine in case.documentation %}
+    /// {{ docLine }}
+    {% endfor %}
+    case {{ case.name }} = "{{ case.annotations["code"] }}"
+    {% endfor %}
+}
+{% endfor %}

--- a/Sources/ZcashLightClientKit/Error/Sourcery/generateErrorCode.sh
+++ b/Sources/ZcashLightClientKit/Error/Sourcery/generateErrorCode.sh
@@ -1,0 +1,33 @@
+#!/bin/zsh
+
+scriptDir=${0:a:h}
+cd "${scriptDir}"
+
+sourcery_version=2.0.2
+
+if which sourcery >/dev/null; then
+    if [[ $(sourcery --version) != $sourcery_version ]]; then
+        echo "warning: Compatible sourcer version not installed. Install sourcer $sourcery_version. Currently installed version is $(sourcer --version)"
+    fi
+
+    sourcery \
+        --disableCache \
+        --parseDocumentation \
+        --verbose \
+        --sources ./ \
+        --sources ../ \
+        --templates ZcashErrorCode.stencil \
+        --output ../ZcashErrorCode.swift
+
+    sourcery \
+        --disableCache \
+        --parseDocumentation \
+        --verbose \
+        --sources ./ \
+        --sources ../ \
+        --templates ZcashError.stencil \
+        --output ../ZcashError.swift
+
+else
+    echo "warning: sourcery not installed"
+fi

--- a/Sources/ZcashLightClientKit/Error/ZcashError.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashError.swift
@@ -1,0 +1,79 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+/*
+!!!!! To edit this file go to ZcashErrorCodeDefinition first and udate/add codes. Then run generateErrorCode.sh script to regenerate this file.
+
+By design each error should be used only at one place in the app. Thanks to that it is possible to identify exact line in the code from which the
+error originates. And it can help with debugging.
+*/
+
+public enum ZcashError: Equatable, Error {
+    /// Some testing code for now. Will be removed later.
+    /// Some multiline super doc:
+    /// - code - Code for error.
+    /// - error - underlying error
+    /// ZTEST0001
+    case testCodeWithMessage(_ code: Int, _ error: Error)
+    /// Unknown GRPC Service error
+    /// ZSRVC0001
+    case serviceUnknownError(_ error: Error)
+    /// LightWalletService.getInfo failed.
+    /// ZSRVC0002
+    case serviceGetInfoFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.latestBlock failed.
+    /// ZSRVC0003
+    case serviceLatestBlockFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.latestBlockHeight failed.
+    /// ZSRVC0004
+    case serviceLatestBlockHeightFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.blockRange failed.
+    /// ZSRVC0005
+    case serviceBlockRangeFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.submit failed.
+    /// ZSRVC0006
+    case serviceSubmitFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.fetchTransaction failed.
+    /// ZSRVC0007
+    case serviceFetchTransactionFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.fetchUTXOs failed.
+    /// ZSRVC0008
+    case serviceFetchUTXOsFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.blockStream failed.
+    /// ZSRVC0000
+    case serviceBlockStreamFailed(_ error: LightWalletServiceError)
+
+    public var message: String {
+        switch self {
+        case .testCodeWithMessage: return "Some testing code for now. Will be removed later."
+        case .serviceUnknownError: return "Unknown GRPC Service error"
+        case .serviceGetInfoFailed: return "LightWalletService.getInfo failed."
+        case .serviceLatestBlockFailed: return "LightWalletService.latestBlock failed."
+        case .serviceLatestBlockHeightFailed: return "LightWalletService.latestBlockHeight failed."
+        case .serviceBlockRangeFailed: return "LightWalletService.blockRange failed."
+        case .serviceSubmitFailed: return "LightWalletService.submit failed."
+        case .serviceFetchTransactionFailed: return "LightWalletService.fetchTransaction failed."
+        case .serviceFetchUTXOsFailed: return "LightWalletService.fetchUTXOs failed."
+        case .serviceBlockStreamFailed: return "LightWalletService.blockStream failed."
+        }
+    }
+
+    public var code: ZcashErrorCode {
+        switch self {
+        case .testCodeWithMessage: return .testCodeWithMessage
+        case .serviceUnknownError: return .serviceUnknownError
+        case .serviceGetInfoFailed: return .serviceGetInfoFailed
+        case .serviceLatestBlockFailed: return .serviceLatestBlockFailed
+        case .serviceLatestBlockHeightFailed: return .serviceLatestBlockHeightFailed
+        case .serviceBlockRangeFailed: return .serviceBlockRangeFailed
+        case .serviceSubmitFailed: return .serviceSubmitFailed
+        case .serviceFetchTransactionFailed: return .serviceFetchTransactionFailed
+        case .serviceFetchUTXOsFailed: return .serviceFetchUTXOsFailed
+        case .serviceBlockStreamFailed: return .serviceBlockStreamFailed
+        }
+    }
+
+    public static func == (lhs: ZcashError, rhs: ZcashError) -> Bool {
+        return lhs.code == rhs.code
+    }
+}

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
@@ -1,0 +1,36 @@
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+/*
+!!!!! To edit this file go to ZcashErrorCodeDefinition first and udate/add codes. Then run generateErrorCode.sh script to regenerate this file.
+
+By design each error code should be used only at one place in the app. Thanks to that it is possible to identify exact line in the code from which the
+error originates. And it can help with debugging.
+*/
+
+public enum ZcashErrorCode: String {
+    /// Some testing code for now. Will be removed later.
+    /// Some multiline super doc:
+    /// - message - Message associated with error
+    /// - code - Code for error.
+    /// - error - underlying error
+    case testCodeWithMessage = "ZTEST0001"
+    /// Unknown GRPC Service error
+    case serviceUnknownError = "ZSRVC0001"
+    /// LightWalletService.getInfo failed.
+    case serviceGetInfoFailed = "ZSRVC0002"
+    /// LightWalletService.latestBlock failed.
+    case serviceLatestBlockFailed = "ZSRVC0003"
+    /// LightWalletService.latestBlockHeight failed.
+    case serviceLatestBlockHeightFailed = "ZSRVC0004"
+    /// LightWalletService.blockRange failed.
+    case serviceBlockRangeFailed = "ZSRVC0005"
+    /// LightWalletService.submit failed.
+    case serviceSubmitFailed = "ZSRVC0006"
+    /// LightWalletService.fetchTransaction failed.
+    case serviceFetchTransactionFailed = "ZSRVC0007"
+    /// LightWalletService.fetchUTXOs failed.
+    case serviceFetchUTXOsFailed = "ZSRVC0008"
+    /// LightWalletService.blockStream failed.
+    case serviceBlockStreamFailed = "ZSRVC0000"
+}

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
@@ -1,0 +1,59 @@
+//
+//  ZcashErrorDefinition.swift
+//  
+//
+//  Created by Michal Fousek on 10.04.2023.
+//
+
+import Foundation
+
+/*
+ This enum won't every be directly used in the code. It is just definition of errors and it used as source for Sourcery. And the files used in the
+ code are then generated. Check `ZcashError` and `ZcashErrorCode`.
+
+ Please pay attention how each error is defined here. Important part is to raw code for each error. And it's important to use /// for the
+ documentation and only // for the sourcery command.
+
+ First line of documentation for each error will be used in automatically generated `message` property.
+
+ Error code should always start with `Z` letter. Then there should be 0-4 letters that marks in which part of the SDK is the code used. And then 4
+ numbers. This is suggestion to keep some order when it comes to error codes. Each code must be unique. `ZcashErrorCode` enum is generated from these
+ codes. So if the code isn't unique generated code won't compile.
+*/
+
+enum ZcashErrorDefinition {
+    /// Some testing code for now. Will be removed later.
+    /// Some multiline super doc:
+    /// - message - Message associated with error
+    /// - code - Code for error.
+    /// - error - underlying error
+    // sourcery: code="ZTEST0001"
+    case testCodeWithMessage(_ message: String, _ code: Int, _ error: Error)
+    /// Unknown GRPC Service error
+    // sourcery: code="ZSRVC0001"
+    case serviceUnknownError(_ error: Error)
+    /// LightWalletService.getInfo failed.
+    // sourcery: code="ZSRVC0002"
+    case serviceGetInfoFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.latestBlock failed.
+    // sourcery: code="ZSRVC0003"
+    case serviceLatestBlockFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.latestBlockHeight failed.
+    // sourcery: code="ZSRVC0004"
+    case serviceLatestBlockHeightFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.blockRange failed.
+    // sourcery: code="ZSRVC0005"
+    case serviceBlockRangeFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.submit failed.
+    // sourcery: code="ZSRVC0006"
+    case serviceSubmitFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.fetchTransaction failed.
+    // sourcery: code="ZSRVC0007"
+    case serviceFetchTransactionFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.fetchUTXOs failed.
+    // sourcery: code="ZSRVC0008"
+    case serviceFetchUTXOsFailed(_ error: LightWalletServiceError)
+    /// LightWalletService.blockStream failed.
+    // sourcery: code="ZSRVC0000"
+    case serviceBlockStreamFailed(_ error: LightWalletServiceError)
+}

--- a/Sources/ZcashLightClientKit/Modules/Service/GRPC/LightWalletGRPCService.swift
+++ b/Sources/ZcashLightClientKit/Modules/Service/GRPC/LightWalletGRPCService.swift
@@ -48,7 +48,8 @@ class LiveLatestBlockHeightProvider: LatestBlockHeightProvider {
             }
             return blockHeight
         } catch {
-            throw error.mapToServiceError()
+            let serviceError = error.mapToServiceError()
+            throw ZcashError.serviceLatestBlockHeightFailed(serviceError)
         }
     }
 }
@@ -128,21 +129,11 @@ class LightWalletGRPCService {
         do {
             return try await compactTxStreamer.getLatestBlock(ChainSpec())
         } catch {
-            throw error.mapToServiceError()
+            let serviceError = error.mapToServiceError()
+            throw ZcashError.serviceLatestBlockFailed(serviceError)
         }
     }
-    
-    func getTx(hash: String) async throws -> RawTransaction {
-        var filter = TxFilter()
-        filter.hash = Data(hash.utf8)
 
-        do {
-            return try await compactTxStreamer.getTransaction(filter)
-        } catch {
-            throw error.mapToServiceError()
-        }
-    }
-    
     static func callOptions(timeLimit: TimeLimit) -> CallOptions {
         CallOptions(
             customMetadata: HPACKHeaders(),
@@ -162,7 +153,8 @@ extension LightWalletGRPCService: LightWalletService {
         do {
             return try await compactTxStreamer.getLightdInfo(Empty())
         } catch {
-            throw error.mapToServiceError()
+            let serviceError = error.mapToServiceError()
+            throw ZcashError.serviceGetInfoFailed(serviceError)
         }
     }
     
@@ -181,7 +173,8 @@ extension LightWalletGRPCService: LightWalletService {
                     }
                     continuation.finish()
                 } catch {
-                    continuation.finish(throwing: error.mapToServiceError())
+                    let serviceError = error.mapToServiceError()
+                    continuation.finish(throwing: ZcashError.serviceBlockRangeFailed(serviceError))
                 }
             }
         }
@@ -192,7 +185,8 @@ extension LightWalletGRPCService: LightWalletService {
             let transaction = RawTransaction.with { $0.data = spendTransaction }
             return try await compactTxStreamer.sendTransaction(transaction)
         } catch {
-            throw LightWalletServiceError.sentFailed(error: error)
+            let serviceError = error.mapToServiceError()
+            throw ZcashError.serviceSubmitFailed(serviceError)
         }
     }
     
@@ -204,7 +198,8 @@ extension LightWalletGRPCService: LightWalletService {
             let rawTx = try await compactTxStreamer.getTransaction(txFilter)
             return ZcashTransaction.Fetched(rawID: txId, minedHeight: BlockHeight(rawTx.height), raw: rawTx.data)
         } catch {
-            throw error.mapToServiceError()
+            let serviceError = error.mapToServiceError()
+            throw ZcashError.serviceFetchTransactionFailed(serviceError)
         }
     }
 
@@ -245,7 +240,8 @@ extension LightWalletGRPCService: LightWalletService {
                     }
                     continuation.finish()
                 } catch {
-                    continuation.finish(throwing: error.mapToServiceError())
+                    let serviceError = error.mapToServiceError()
+                    continuation.finish(throwing: ZcashError.serviceFetchUTXOsFailed(serviceError))
                 }
             }
         }
@@ -271,7 +267,8 @@ extension LightWalletGRPCService: LightWalletService {
                     }
                     continuation.finish()
                 } catch {
-                    continuation.finish(throwing: error.mapToServiceError())
+                    let serviceError = error.mapToServiceError()
+                    continuation.finish(throwing: ZcashError.serviceBlockStreamFailed(serviceError))
                 }
             }
         }

--- a/Sources/ZcashLightClientKit/Modules/Service/LightWalletService.swift
+++ b/Sources/ZcashLightClientKit/Modules/Service/LightWalletService.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
 Wrapper for errors received from a Lightwalletd endpoint
 */
-enum LightWalletServiceError: Error {
+public enum LightWalletServiceError: Error {
     case generalError(message: String)
     case failed(statusCode: Int, message: String)
     case invalidBlock
@@ -25,7 +25,7 @@ enum LightWalletServiceError: Error {
 
 extension LightWalletServiceError: Equatable {
     // swiftlint:disable cyclomatic_complexity
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         switch lhs {
         case .generalError(let message):
             switch rhs {
@@ -151,31 +151,41 @@ protocol LightWalletService: AnyObject {
     var connectionStateChange: ((_ from: ConnectionState, _ to: ConnectionState) -> Void)? { get set }
 
     /// Returns the info for this lightwalletd server
+    /// Throws `serviceGetInfoFailed` when GRPC call fails.
     func getInfo() async throws -> LightWalletdInfo
 
+    /// Throws `serviceLatestBlockHeightFailed` when GRPC call fails.
+    func latestBlock() async throws -> BlockID
+
     /// Return the latest block height known to the service.
-    /// Blocking API
+    /// Throws `serviceLatestBlockFailed` when GRPC call fails.
     func latestBlockHeight() async throws -> BlockHeight
 
     /// Return the given range of blocks.
     /// - Parameter range: the inclusive range to fetch.
     ///     For instance if 1..5 is given, then every block in that will be fetched, including 1 and 5.
+    /// Stream throws `serviceBlockRangeFailed` when GRPC call fails.
     func blockRange(_ range: CompactBlockRange) -> AsyncThrowingStream<ZcashCompactBlock, Error>
     
     /// Submits a raw transaction over lightwalletd. Non-Blocking
     /// - Parameter spendTransaction: data representing the transaction to be sent
+    /// Throws `serviceSubmitFailed` when GRPC call fails.
     func submit(spendTransaction: Data) async throws -> LightWalletServiceResponse
     
     /// Gets a transaction by id
     /// - Parameter txId: data representing the transaction ID
     /// - Throws: LightWalletServiceError
     /// - Returns: LightWalletServiceResponse
+    /// Throws `serviceFetchTransactionFailed` when GRPC call fails.
     func fetchTransaction(txId: Data) async throws -> ZcashTransaction.Fetched
-    
+
+    /// Stream throws `serviceFetchUTXOsFailed` when GRPC call fails.
     func fetchUTXOs(for tAddress: String, height: BlockHeight) -> AsyncThrowingStream<UnspentTransactionOutputEntity, Error>
-    
+
+    /// Stream throws `serviceFetchUTXOsFailed` when GRPC call fails.
     func fetchUTXOs(for tAddresses: [String], height: BlockHeight) -> AsyncThrowingStream<UnspentTransactionOutputEntity, Error>
-    
+
+    /// Throws `serviceBlockStreamFailed` when GRPC call fails.
     func blockStream(
         startHeight: BlockHeight,
         endHeight: BlockHeight

--- a/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/ClosureSynchronizerOfflineTests.swift
@@ -11,8 +11,6 @@ import Foundation
 import XCTest
 @testable import ZcashLightClientKit
 
-extension String: Error { }
-
 class ClosureSynchronizerOfflineTests: XCTestCase {
     var data: TestsData!
 

--- a/Tests/TestUtils/DarkSideWalletService.swift
+++ b/Tests/TestUtils/DarkSideWalletService.swift
@@ -65,6 +65,10 @@ class DarksideWalletService: LightWalletService {
     func blockStream(startHeight: BlockHeight, endHeight: BlockHeight) -> AsyncThrowingStream<ZcashCompactBlock, Error> {
         service.blockStream(startHeight: startHeight, endHeight: endHeight)
     }
+
+    func latestBlock() async throws -> ZcashLightClientKit.BlockID {
+        throw "Not mocked"
+    }
     
     func closeConnection() {
     }

--- a/Tests/TestUtils/FakeService.swift
+++ b/Tests/TestUtils/FakeService.swift
@@ -32,6 +32,10 @@ class MockLightWalletService: LightWalletService {
         service.blockStream(startHeight: startHeight, endHeight: endHeight)
     }
 
+    func latestBlock() async throws -> ZcashLightClientKit.BlockID {
+        throw "Not mocked"
+    }
+
     func closeConnection() {
     }
 

--- a/Tests/TestUtils/Stubs.swift
+++ b/Tests/TestUtils/Stubs.swift
@@ -11,6 +11,8 @@ import GRPC
 import SwiftProtobuf
 @testable import ZcashLightClientKit
 
+extension String: Error { }
+
 class AwfulLightWalletService: MockLightWalletService {
     override func latestBlockHeight() async throws -> BlockHeight {
         throw LightWalletServiceError.criticalError


### PR DESCRIPTION
This PR introduces `ZcashError` enum. This enum represents any error that can be thrown inside of the SDK and outside of the SDK. Also `ZcashError` is used in `LightWalletGRPCService` and handled in `CompactBlockProcessor` as example.

Why enum? First I tried this with some structure which contained code, message and underlyingError. Problem was when some specific place in the SDK would like to attach some additional data to error. I didn't want to add some generic dictionary to store anything with the error.

So I used enum to identify error. Each member can have specified amount of associated values. So specific error can bring some context data. And it's type safe.

Each error has also a code. Relationship between errors and codes is 1:1. It may looks bit redundant but it's important. The client app now can choose how to process errors. Either identify those by the error itself or by code.

Definition or errors and codes is in `ZcashErrorDefinition`. And then `ZcashError` and `ZcashErrorCode` are generated by Sourcery. Thanks to this it is easier to maintain the final code. And it gives us ability to generate any kind of documentation for the errors and codes. I created simple example of this in this PR. And it doesn't make the SDK completely dependent on the Sourcery. Final structures aren't super complicated and can be written manually if needed.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.