### PR TITLE
[#1013] - Enable more granular control over logging behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### [#1013] Enable more granular control over logging behavior
+
+Now the SDK allows for more fine-tuning of its logging behavior. The `LoggingPolicy` enum
+provides for three options: `.default(OSLogger.LogLevel)` wherein the SDK will use its own logger, with the option
+to customize the log level by passing an `OSLogger.LogLevel` to the enum case. 
+`custom` allows one to pass a custom `Logger` implementation for completely customized logging.
+Lastly, `noLogging` disables logging entirely.
+
+To utilize this new configuration option, pass a `loggingPolicy` into the `Initializer`. If unspecified, the SDK
+will utilize an internal `Logger` implementation with an `OSLogger.LogLevel` of `.debug`
+
 # 0.21.0-beta
 
 New checkpoints

--- a/Example/ZcashLightClientSample/ZcashLightClientSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift.git",
       "state" : {
-        "revision" : "783ed8ddcde07ac0332a5ec4647b665f82e95b78",
-        "version" : "1.14.0"
+        "revision" : "130467153ff0acd642d2f098b69c1ac33373b24e",
+        "version" : "1.15.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
-        "version" : "1.0.3"
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "45167b8006448c79dda4b7bd604e07a034c15c49",
-        "version" : "2.48.0"
+        "revision" : "d1690f85419fdac8d54e350fb6d2ab9fd95afd75",
+        "version" : "2.51.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
-        "version" : "1.10.2"
+        "revision" : "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+        "version" : "1.19.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "22757ac305f3d44d2b99ba541193ff1d64e77d00",
-        "version" : "1.24.1"
+        "revision" : "6d021a48483dbb273a9be43f65234bdc9185b364",
+        "version" : "1.26.0"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
+        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
+        "version" : "2.24.0"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-        "version" : "1.15.0"
+        "revision" : "41f4098903878418537020075a4d8a6e20a0b182",
+        "version" : "1.17.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
-        "version" : "1.20.3"
+        "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
+        "version" : "1.21.0"
       }
     },
     {
@@ -158,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zcash-hackworks/zcash-light-client-ffi",
       "state" : {
-        "revision" : "bf5992c2e53749ad11c1e85ad5d9c63e39bdf3cc",
-        "version" : "0.3.0"
+        "revision" : "75821e2b859600707318e4a788abbe27e6615833",
+        "version" : "0.3.1"
       }
     }
   ],

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
@@ -114,7 +114,7 @@ class SyncBlocksListViewController: UIViewController {
             outputParamsURL: try! outputParamsURLHelper(),
             saplingParamsSourceURL: SaplingParamsSourceURL.default,
             alias: data.alias,
-            logLevel: .debug
+            loggingPolicy: .default(.debug)
         )
 
         return SDKSynchronizer(initializer: initializer)

--- a/README.md
+++ b/README.md
@@ -71,9 +71,15 @@ public protocol Logger {
     
 }
 ```
-To enable logging you need to do 2 simple steps:
-1. have one class conform the `Logger` protocol
-2. inject that logger when creating the `Initializer`
+
+You have a few different options when it comes to logging:
+1. Leave it to the SDK. It will use its own `Logger` with sensible defaults. For this option, simply omit the `loggingPolicy` parameter when creating the `Initializer`
+
+2. Provide a custom logger. For this option, do the following:
+    a). have one class conform to the `Logger` protocol
+    b). inject that logger when creating the `Initializer` by passing a `loggingPolicy` of `.custom(yourLogger)`
+
+3. No logging. The SDK will not log any events. For this option, pass a `loggingPolicy` of `.noLogging` when creating the `Initializer` 
 
 For more details look the Sample App's `AppDelegate` code.
 

--- a/Sources/ZcashLightClientKit/Utils/LoggingProxy.swift
+++ b/Sources/ZcashLightClientKit/Utils/LoggingProxy.swift
@@ -43,3 +43,14 @@ extension Logger {
         error(message, file: file, function: function, line: line)
     }
 }
+
+/**
+A concrete logger implementation that logs nothing at all
+ */
+struct NullLogger: Logger {
+    func debug(_ message: String, file: StaticString, function: StaticString, line: Int) {}
+    func info(_ message: String, file: StaticString, function: StaticString, line: Int) {}
+    func event(_ message: String, file: StaticString, function: StaticString, line: Int) {}
+    func warn(_ message: String, file: StaticString, function: StaticString, line: Int) {}
+    func error(_ message: String, file: StaticString, function: StaticString, line: Int) {}
+}

--- a/Tests/OfflineTests/InitializerOfflineTests.swift
+++ b/Tests/OfflineTests/InitializerOfflineTests.swift
@@ -36,7 +36,7 @@ class InitializerOfflineTests: XCTestCase {
             outputParamsURL: outputParamsURL,
             saplingParamsSourceURL: .default,
             alias: alias,
-            logLevel: .debug
+            loggingPolicy: .default(.debug)
         )
     }
 

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -249,7 +249,7 @@ class SynchronizerOfflineTests: XCTestCase {
             outputParamsURL: validFileURL,
             saplingParamsSourceURL: .default,
             alias: .default,
-            logLevel: .debug
+            loggingPolicy: .default(.debug)
         )
 
         XCTAssertNotNil(initializer.urlsParsingError)
@@ -290,7 +290,7 @@ class SynchronizerOfflineTests: XCTestCase {
             outputParamsURL: validFileURL,
             saplingParamsSourceURL: .default,
             alias: .default,
-            logLevel: .debug
+            loggingPolicy: .default(.debug)
         )
 
         XCTAssertNotNil(initializer.urlsParsingError)

--- a/Tests/PerformanceTests/SynchronizerTests.swift
+++ b/Tests/PerformanceTests/SynchronizerTests.swift
@@ -79,7 +79,7 @@ class SynchronizerTests: XCTestCase {
                 outputParamsURL: try __outputParamsURL(),
                 saplingParamsSourceURL: SaplingParamsSourceURL.tests,
                 alias: .default,
-                logLevel: .debug
+                loggingPolicy: .default(.debug)
             )
             
             try? FileManager.default.removeItem(at: databases.fsCacheDbRoot)

--- a/Tests/TestUtils/TestCoordinator.swift
+++ b/Tests/TestUtils/TestCoordinator.swift
@@ -77,7 +77,7 @@ class TestCoordinator {
             outputParamsURL: try __outputParamsURL(),
             saplingParamsSourceURL: SaplingParamsSourceURL.tests,
             alias: alias,
-            logLevel: .debug
+            loggingPolicy: .default(.debug)
         )
 
         let derivationTool = DerivationTool(networkType: network.networkType)


### PR DESCRIPTION
The `Initializer` struct now takes a `LoggingPolicy` parameter, which enables the following options when initializing the SDK:

- `default` - the SDK will default to using its own internal implementation of the `Logger` protocol at the `debug` log level. You can also override the log level by passing your preferred log level in to the enum case.
- `custom` - the user provides an object conforming to the `Logger` protocol, allowing for complete customizability of the logging.
- `noLogging` - the SDK will not log anything

Closes #1013 

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [x] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.