### PR TITLE
[#1111] Change storage for InternalSyncProgress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+### [#1111] Change how the sync progress is stored inside the SDK
+
+`Initializer` has now a new parameter called `generalStorageURL`. This URL is the location of the directory 
+where the SDK can store any information it needs. A directory doesn't have to exist. But the SDK must 
+be able to write to this location after it creates this directory. It is suggested that this directory is
+a subdirectory of the `Documents` directory. If this information is stored in `Documents` then the
+system itself won't remove these data.
+
 # 0.22.0-beta
 
 ## Checkpoints
@@ -38,6 +48,16 @@ Sources/ZcashLightClientKit/Resources/checkpoints/testnet/2340000.json
 This fixes a memory consumption issue coming from GRPC-Swift.
 - [#1019] Memo has trailing garbled text
  
+### [#1111] Change how the sync progress is stored inside the SDK
+
+`Initializer` has now a new parameter called `generalStorageURL`. This URL is the location of the directory 
+where the SDK can store any information it needs. A directory doesn't have to exist. But the SDK must 
+be able to write to this location after it creates this directory. It is suggested that this directory is
+a subdirectory of the `Documents` directory. If this information is stored in `Documents` then the
+system itself won't remove these data.
+
+### [#1019] Memo has trailing garbled text
+    
 Changes the way unpadded bytes are turned into a UTF-8 Swift String
 without using cString assuming APIs that would overflow memory and
 add garbled trailing bytes.

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/AppDelegate.swift
@@ -46,6 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let wallet = Initializer(
                 cacheDbURL: nil,
                 fsBlockDbRoot: try! fsBlockDbRootURLHelper(),
+                generalStorageURL: try! generalStorageURLHelper(),
                 dataDbURL: try! dataDbURLHelper(),
                 endpoint: DemoAppConfig.endpoint,
                 network: kZcashNetwork,
@@ -168,6 +169,15 @@ func fsBlockDbRootURLHelper() throws -> URL {
         .appendingPathComponent(kZcashNetwork.networkType.chainName)
         .appendingPathComponent(
             ZcashSDK.defaultFsCacheName,
+            isDirectory: true
+        )
+}
+
+func generalStorageURLHelper() throws -> URL {
+    try documentsDirectoryHelper()
+        .appendingPathComponent(kZcashNetwork.networkType.chainName)
+        .appendingPathComponent(
+            "general_storage",
             isDirectory: true
         )
 }

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
@@ -104,6 +104,7 @@ class SyncBlocksListViewController: UIViewController {
         let initializer = Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: try! fsBlockDbRootURLHelper(),
+            generalStorageURL: try! generalStorageURLHelper(),
             dataDbURL: try! dataDbURLHelper(),
             endpoint: DemoAppConfig.endpoint,
             network: kZcashNetwork,

--- a/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
+++ b/Sources/ZcashLightClientKit/Block/Enhance/BlockEnhancer.swift
@@ -52,7 +52,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
             let transactions = try await transactionRepository.find(in: range, limit: Int.max, kind: .all)
 
             guard !transactions.isEmpty else {
-                await internalSyncProgress.set(range.upperBound, .latestEnhancedHeight)
+                try await internalSyncProgress.set(range.upperBound, .latestEnhancedHeight)
                 logger.debug("no transactions detected on range: \(range.lowerBound)...\(range.upperBound)")
                 return nil
             }
@@ -84,7 +84,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
                         await didEnhance(progress)
 
                         if let minedHeight = confirmedTx.minedHeight {
-                            await internalSyncProgress.set(minedHeight, .latestEnhancedHeight)
+                            try await internalSyncProgress.set(minedHeight, .latestEnhancedHeight)
                         }
                     } catch {
                         retries += 1
@@ -112,7 +112,7 @@ extension BlockEnhancerImpl: BlockEnhancer {
             throw error
         }
 
-        await internalSyncProgress.set(range.upperBound, .latestEnhancedHeight)
+        try await internalSyncProgress.set(range.upperBound, .latestEnhancedHeight)
         
         if Task.isCancelled {
             logger.debug("Warning: compactBlockEnhancement on range \(range) cancelled")

--- a/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
+++ b/Sources/ZcashLightClientKit/Block/FetchUnspentTxOutputs/UTXOFetcher.swift
@@ -82,7 +82,7 @@ extension UTXOFetcherImpl: UTXOFetcher {
 
                 counter += 1
                 await didFetch(counter / all)
-                await internalSyncProgress.set(utxo.height, .latestUTXOFetchedHeight)
+                try await internalSyncProgress.set(utxo.height, .latestUTXOFetchedHeight)
             } catch {
                 logger.error("failed to put utxo - error: \(error)")
                 skipped.append(utxo)
@@ -103,7 +103,7 @@ extension UTXOFetcherImpl: UTXOFetcher {
 
         let result = (inserted: refreshed, skipped: skipped)
 
-        await internalSyncProgress.set(range.upperBound, .latestUTXOFetchedHeight)
+        try await internalSyncProgress.set(range.upperBound, .latestUTXOFetchedHeight)
 
         if Task.isCancelled {
             logger.debug("Warning: fetchUnspentTxOutputs on range \(range) cancelled")

--- a/Sources/ZcashLightClientKit/Block/Utils/InternalSyncProgressDiskStorage.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/InternalSyncProgressDiskStorage.swift
@@ -1,0 +1,97 @@
+//
+//  InternalSyncProgressDiskStorage.swift
+//  
+//
+//  Created by Michal Fousek on 21.05.2023.
+//
+
+import Foundation
+
+actor InternalSyncProgressDiskStorage {
+    private let storageURL: URL
+    private let logger: Logger
+    init(storageURL: URL, logger: Logger) {
+        self.storageURL = storageURL
+        self.logger = logger
+    }
+
+    private func fileURL(for key: String) -> URL {
+        return storageURL.appendingPathComponent(key)
+    }
+}
+
+extension InternalSyncProgressDiskStorage: InternalSyncProgressStorage {
+    /// - If object on the file system at `generalStorageURL` exists and it is directory then do nothing.
+    /// - If object on the file system at `generalStorageURL` exists and it is file then throw error. Because `generalStorageURL` should be directory.
+    /// - If object on the file system at `generalStorageURL` doesn't exists then create directory at this URL. And set `isExcludedFromBackup` URL
+    ///   flag to prevent backup of the progress information to system backup.
+    func initialize() async throws {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: storageURL.pathExtension, isDirectory: &isDirectory)
+
+        if exists && !isDirectory.boolValue {
+            throw ZcashError.initializerGeneralStorageExistsButIsFile(storageURL)
+        } else if !exists {
+            do {
+                try fileManager.createDirectory(at: storageURL, withIntermediateDirectories: true)
+            } catch {
+                throw ZcashError.initializerGeneralStorageCantCreate(storageURL, error)
+            }
+
+            do {
+                // Prevent from backing up progress information to system backup.
+                var resourceValues = URLResourceValues()
+                resourceValues.isExcludedFromBackup = true
+                var generalStorageURL = storageURL
+                try generalStorageURL.setResourceValues(resourceValues)
+            } catch {
+                throw ZcashError.initializerCantSetNoBackupFlagToGeneralStorageURL(storageURL, error)
+            }
+        }
+    }
+
+    func bool(for key: String) async throws -> Bool {
+        let fileURL = self.fileURL(for: key)
+        do {
+            return try Data(contentsOf: fileURL).toBool()
+        } catch {
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                return false
+            } else {
+                throw ZcashError.ispStorageCantLoad(fileURL, error)
+            }
+        }
+    }
+
+    func integer(for key: String) async throws -> Int {
+        let fileURL = self.fileURL(for: key)
+        do {
+            return try Data(contentsOf: fileURL).toInt()
+        } catch {
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                return 0
+            } else {
+                throw ZcashError.ispStorageCantLoad(fileURL, error)
+            }
+        }
+    }
+
+    func set(_ value: Int, for key: String) async throws {
+        let fileURL = self.fileURL(for: key)
+        do {
+            try value.toData().write(to: fileURL, options: [.atomic])
+        } catch {
+            throw ZcashError.ispStorageCantWrite(fileURL, error)
+        }
+    }
+
+    func set(_ value: Bool, for key: String) async throws {
+        let fileURL = self.fileURL(for: key)
+        do {
+            try value.toData().write(to: fileURL, options: [.atomic])
+        } catch {
+            throw ZcashError.ispStorageCantWrite(fileURL, error)
+        }
+    }
+}

--- a/Sources/ZcashLightClientKit/Error/ZcashError.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashError.swift
@@ -11,8 +11,9 @@ error originates. And it can help with debugging.
 import Foundation
 
 public enum ZcashError: Equatable, Error {
-    /// Some error happened that is not handled as `ZcashError`.
-    /// Use case is to map `any Error`(in the apps for example) to this one so it can be assured only `ZcashError` is floating through apps.
+    /// Some error happened that is not handled as `ZcashError`. All errors in the SDK are (should be) `ZcashError`.
+    /// This case is ideally not contructed directly or thrown by any SDK function, rather it's a wrapper for case clients expect ZcashErrot and want to pass it to a function/enum.
+    /// If this is the case, use `toZcashError()` extension of Error. This helper avoids to end up with Optional handling.
     /// ZUNKWN0001
     case unknown(_ error: Error)
     /// Updating of paths in `Initilizer` according to alias failed.
@@ -21,6 +22,15 @@ public enum ZcashError: Equatable, Error {
     /// Alias used to create this instance of the `SDKSynchronizer` is already used by other instance.
     /// ZINIT0002
     case initializerAliasAlreadyInUse(_ alias: ZcashSynchronizerAlias)
+    /// Object on disk at `generalStorageURL` path exists. But it file not directory.
+    /// ZINIT0003
+    case initializerGeneralStorageExistsButIsFile(_ generalStorageURL: URL)
+    /// Can't create directory at `generalStorageURL` path.
+    /// ZINIT0004
+    case initializerGeneralStorageCantCreate(_ generalStorageURL: URL, _ error: Error)
+    /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
+    /// ZINIT0005
+    case initializerCantSetNoBackupFlagToGeneralStorageURL(_ generalStorageURL: URL, _ error: Error)
     /// Unknown GRPC Service error
     /// ZSRVC0001
     case serviceUnknownError(_ error: Error)
@@ -509,12 +519,21 @@ public enum ZcashError: Equatable, Error {
     /// Indicates that this Synchronizer is disconnected from its lightwalletd server.
     /// ZSYNCO0006
     case synchronizerDisconnected
+    /// `InternalSyncProgressDiskStorage` can't read data from specific file.
+    /// ZISPDS0001
+    case ispStorageCantLoad(_ fileURL: URL, _ error: Error)
+    /// `InternalSyncProgressDiskStorage` can't write data from specific file.
+    /// ZISPDS0002
+    case ispStorageCantWrite(_ fileURL: URL, _ error: Error)
 
     public var message: String {
         switch self {
-        case .unknown: return "Some error happened that is not handled as `ZcashError`."
+        case .unknown: return "Some error happened that is not handled as `ZcashError`. All errors in the SDK are (should be) `ZcashError`."
         case .initializerCantUpdateURLWithAlias: return "Updating of paths in `Initilizer` according to alias failed."
         case .initializerAliasAlreadyInUse: return "Alias used to create this instance of the `SDKSynchronizer` is already used by other instance."
+        case .initializerGeneralStorageExistsButIsFile: return "Object on disk at `generalStorageURL` path exists. But it file not directory."
+        case .initializerGeneralStorageCantCreate: return "Can't create directory at `generalStorageURL` path."
+        case .initializerCantSetNoBackupFlagToGeneralStorageURL: return "Can't set `isExcludedFromBackup` flag to `generalStorageURL`."
         case .serviceUnknownError: return "Unknown GRPC Service error"
         case .serviceGetInfoFailed: return "LightWalletService.getInfo failed."
         case .serviceLatestBlockFailed: return "LightWalletService.latestBlock failed."
@@ -659,6 +678,8 @@ public enum ZcashError: Equatable, Error {
         case .synchronizerLatestUTXOsInvalidTAddress: return "LatestUTXOs for the address failed, invalid t-address."
         case .synchronizerRewindUnknownArchorHeight: return "Rewind failed, unknown archor height"
         case .synchronizerDisconnected: return "Indicates that this Synchronizer is disconnected from its lightwalletd server."
+        case .ispStorageCantLoad: return "`InternalSyncProgressDiskStorage` can't read data from specific file."
+        case .ispStorageCantWrite: return "`InternalSyncProgressDiskStorage` can't write data from specific file."
         }
     }
 
@@ -667,6 +688,9 @@ public enum ZcashError: Equatable, Error {
         case .unknown: return .unknown
         case .initializerCantUpdateURLWithAlias: return .initializerCantUpdateURLWithAlias
         case .initializerAliasAlreadyInUse: return .initializerAliasAlreadyInUse
+        case .initializerGeneralStorageExistsButIsFile: return .initializerGeneralStorageExistsButIsFile
+        case .initializerGeneralStorageCantCreate: return .initializerGeneralStorageCantCreate
+        case .initializerCantSetNoBackupFlagToGeneralStorageURL: return .initializerCantSetNoBackupFlagToGeneralStorageURL
         case .serviceUnknownError: return .serviceUnknownError
         case .serviceGetInfoFailed: return .serviceGetInfoFailed
         case .serviceLatestBlockFailed: return .serviceLatestBlockFailed
@@ -811,6 +835,8 @@ public enum ZcashError: Equatable, Error {
         case .synchronizerLatestUTXOsInvalidTAddress: return .synchronizerLatestUTXOsInvalidTAddress
         case .synchronizerRewindUnknownArchorHeight: return .synchronizerRewindUnknownArchorHeight
         case .synchronizerDisconnected: return .synchronizerDisconnected
+        case .ispStorageCantLoad: return .ispStorageCantLoad
+        case .ispStorageCantWrite: return .ispStorageCantWrite
         }
     }
 

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCode.swift
@@ -9,12 +9,18 @@ error originates. And it can help with debugging.
 */
 
 public enum ZcashErrorCode: String {
-    /// Some error happened that is not handled as `ZcashError`.
+    /// Some error happened that is not handled as `ZcashError`. All errors in the SDK are (should be) `ZcashError`.
     case unknown = "ZUNKWN0001"
     /// Updating of paths in `Initilizer` according to alias failed.
     case initializerCantUpdateURLWithAlias = "ZINIT0001"
     /// Alias used to create this instance of the `SDKSynchronizer` is already used by other instance.
     case initializerAliasAlreadyInUse = "ZINIT0002"
+    /// Object on disk at `generalStorageURL` path exists. But it file not directory.
+    case initializerGeneralStorageExistsButIsFile = "ZINIT0003"
+    /// Can't create directory at `generalStorageURL` path.
+    case initializerGeneralStorageCantCreate = "ZINIT0004"
+    /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
+    case initializerCantSetNoBackupFlagToGeneralStorageURL = "ZINIT0005"
     /// Unknown GRPC Service error
     case serviceUnknownError = "ZSRVC0001"
     /// LightWalletService.getInfo failed.
@@ -303,4 +309,8 @@ public enum ZcashErrorCode: String {
     case synchronizerRewindUnknownArchorHeight = "ZSYNCO0005"
     /// Indicates that this Synchronizer is disconnected from its lightwalletd server.
     case synchronizerDisconnected = "ZSYNCO0006"
+    /// `InternalSyncProgressDiskStorage` can't read data from specific file.
+    case ispStorageCantLoad = "ZISPDS0001"
+    /// `InternalSyncProgressDiskStorage` can't write data from specific file.
+    case ispStorageCantWrite = "ZISPDS0002"
 }

--- a/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
+++ b/Sources/ZcashLightClientKit/Error/ZcashErrorCodeDefinition.swift
@@ -38,6 +38,15 @@ enum ZcashErrorDefinition {
     /// Alias used to create this instance of the `SDKSynchronizer` is already used by other instance.
     // sourcery: code="ZINIT0002"
     case initializerAliasAlreadyInUse(_ alias: ZcashSynchronizerAlias)
+    /// Object on disk at `generalStorageURL` path exists. But it file not directory.
+    // sourcery: code="ZINIT0003"
+    case initializerGeneralStorageExistsButIsFile(_ generalStorageURL: URL)
+    /// Can't create directory at `generalStorageURL` path.
+    // sourcery: code="ZINIT0004"
+    case initializerGeneralStorageCantCreate(_ generalStorageURL: URL, _ error: Error)
+    /// Can't set `isExcludedFromBackup` flag to `generalStorageURL`.
+    // sourcery: code="ZINIT0005"
+    case initializerCantSetNoBackupFlagToGeneralStorageURL(_ generalStorageURL: URL, _ error: Error)
 
     // MARK: - LightWalletService
 
@@ -593,4 +602,13 @@ enum ZcashErrorDefinition {
     /// Indicates that this Synchronizer is disconnected from its lightwalletd server.
     // sourcery: code="ZSYNCO0006"
     case synchronizerDisconnected
+
+    // MARK: - InternalSyncProgressDiskStorage
+
+    /// `InternalSyncProgressDiskStorage` can't read data from specific file.
+    // sourcery: code="ZISPDS0001"
+    case ispStorageCantLoad(_ fileURL: URL, _ error: Error)
+    /// `InternalSyncProgressDiskStorage` can't write data from specific file.
+    // sourcery: code="ZISPDS0002"
+    case ispStorageCantWrite(_ fileURL: URL, _ error: Error)
 }

--- a/Sources/ZcashLightClientKit/Extensions/Bool+ToData.swift
+++ b/Sources/ZcashLightClientKit/Extensions/Bool+ToData.swift
@@ -1,0 +1,15 @@
+//
+//  Bool+ToData.swift
+//  
+//
+//  Created by Michal Fousek on 21.05.2023.
+//
+
+import Foundation
+
+extension Bool {
+    func toData() -> Data {
+        var value = self
+        return withUnsafeBytes(of: &value) { Data($0) }
+    }
+}

--- a/Sources/ZcashLightClientKit/Extensions/Data+ToOtherTypes.swift
+++ b/Sources/ZcashLightClientKit/Extensions/Data+ToOtherTypes.swift
@@ -1,0 +1,18 @@
+//
+//  Data+ToOtherTypes.swift
+//  
+//
+//  Created by Michal Fousek on 21.05.2023.
+//
+
+import Foundation
+
+extension Data {
+    func toInt() -> Int {
+        return self.withUnsafeBytes { $0.load(as: Int.self) }
+    }
+
+    func toBool() -> Bool {
+        return self.withUnsafeBytes { $0.load(as: Bool.self) }
+    }
+}

--- a/Sources/ZcashLightClientKit/Extensions/Int+ToData.swift
+++ b/Sources/ZcashLightClientKit/Extensions/Int+ToData.swift
@@ -1,0 +1,15 @@
+//
+//  Int+ToData.swift
+//  
+//
+//  Created by Michal Fousek on 21.05.2023.
+//
+
+import Foundation
+
+extension Int {
+    func toData() -> Data {
+        var value = self
+        return withUnsafeBytes(of: &value) { Data($0) }
+    }
+}

--- a/Sources/ZcashLightClientKit/Initializer.swift
+++ b/Sources/ZcashLightClientKit/Initializer.swift
@@ -90,6 +90,7 @@ public class Initializer {
     struct URLs {
         let fsBlockDbRoot: URL
         let dataDbURL: URL
+        let generalStorageURL: URL
         let spendParamsURL: URL
         let outputParamsURL: URL
     }
@@ -112,6 +113,7 @@ public class Initializer {
     let alias: ZcashSynchronizerAlias
     let endpoint: LightWalletEndpoint
     let fsBlockDbRoot: URL
+    let generalStorageURL: URL
     let dataDbURL: URL
     let spendParamsURL: URL
     let outputParamsURL: URL
@@ -142,6 +144,10 @@ public class Initializer {
     ///  - cacheDbURL: previous location of the cacheDb. If you don't know what a cacheDb is and you are adopting this SDK for the first time then
     ///                just pass `nil` here.
     ///  - fsBlockDbRoot: location of the compact blocks cache
+    ///  - generalStorageURL: Location of the directory where the SDK can store any information it needs. A directory doesn't have to exist. But the
+    ///                       SDK must be able to write to this location after it creates this directory. It is suggested that this directory is
+    ///                       a subdirectory of the `Documents` directory. If this information is stored in `Documents` then the system itself won't
+    ///                       remove these data.
     ///  - dataDbURL: Location of the data db
     ///  - endpoint: the endpoint representing the lightwalletd instance you want to point to
     ///  - spendParamsURL: location of the spend parameters
@@ -149,6 +155,7 @@ public class Initializer {
     convenience public init(
         cacheDbURL: URL?,
         fsBlockDbRoot: URL,
+        generalStorageURL: URL,
         dataDbURL: URL,
         endpoint: LightWalletEndpoint,
         network: ZcashNetwork,
@@ -166,6 +173,7 @@ public class Initializer {
             container: container,
             cacheDbURL: cacheDbURL,
             fsBlockDbRoot: fsBlockDbRoot,
+            generalStorageURL: generalStorageURL,
             dataDbURL: dataDbURL,
             endpoint: endpoint,
             network: network,
@@ -194,6 +202,7 @@ public class Initializer {
         container: DIContainer,
         cacheDbURL: URL?,
         fsBlockDbRoot: URL,
+        generalStorageURL: URL,
         dataDbURL: URL,
         endpoint: LightWalletEndpoint,
         network: ZcashNetwork,
@@ -209,6 +218,7 @@ public class Initializer {
             container: container,
             cacheDbURL: cacheDbURL,
             fsBlockDbRoot: fsBlockDbRoot,
+            generalStorageURL: generalStorageURL,
             dataDbURL: dataDbURL,
             endpoint: endpoint,
             network: network,
@@ -247,6 +257,7 @@ public class Initializer {
         self.cacheDbURL = cacheDbURL
         self.rustBackend = container.resolve(ZcashRustBackendWelding.self)
         self.fsBlockDbRoot = urls.fsBlockDbRoot
+        self.generalStorageURL = urls.generalStorageURL
         self.dataDbURL = urls.dataDbURL
         self.endpoint = endpoint
         self.spendParamsURL = urls.spendParamsURL
@@ -278,6 +289,7 @@ public class Initializer {
         container: DIContainer,
         cacheDbURL: URL?,
         fsBlockDbRoot: URL,
+        generalStorageURL: URL,
         dataDbURL: URL,
         endpoint: LightWalletEndpoint,
         network: ZcashNetwork,
@@ -290,6 +302,7 @@ public class Initializer {
         let urls = URLs(
             fsBlockDbRoot: fsBlockDbRoot,
             dataDbURL: dataDbURL,
+            generalStorageURL: generalStorageURL,
             spendParamsURL: spendParamsURL,
             outputParamsURL: outputParamsURL
         )
@@ -360,10 +373,15 @@ public class Initializer {
             return .failure(.initializerCantUpdateURLWithAlias(urls.outputParamsURL))
         }
 
+        guard let updatedGeneralStorageURL = urls.generalStorageURL.updateLastPathComponent(with: alias) else {
+            return .failure(.initializerCantUpdateURLWithAlias(urls.generalStorageURL))
+        }
+
         return .success(
             URLs(
                 fsBlockDbRoot: updatedFsBlockDbRoot,
                 dataDbURL: updatedDataDbURL,
+                generalStorageURL: updatedGeneralStorageURL,
                 spendParamsURL: updatedSpendParamsURL,
                 outputParamsURL: updateOutputParamsURL
             )

--- a/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/Dependencies.swift
@@ -89,7 +89,8 @@ enum Dependencies {
 
         container.register(type: InternalSyncProgress.self, isSingleton: true) { di in
             let logger = di.resolve(Logger.self)
-            return InternalSyncProgress(alias: alias, storage: UserDefaults.standard, logger: logger)
+            let storage = InternalSyncProgressDiskStorage(storageURL: urls.generalStorageURL, logger: logger)
+            return InternalSyncProgress(alias: alias, storage: storage, logger: logger)
         }
     }
     

--- a/Tests/DarksideTests/BalanceTests.swift
+++ b/Tests/DarksideTests/BalanceTests.swift
@@ -672,7 +672,7 @@ class BalanceTests: ZcashTestCase {
             return
         }
 
-        guard let changeOutput = outputs.first(where: { $0.isChange }) else {
+        guard outputs.first(where: { $0.isChange }) != nil else {
             XCTFail("Sent transaction has no change")
             return
         }

--- a/Tests/DarksideTests/SynchronizerDarksideTests.swift
+++ b/Tests/DarksideTests/SynchronizerDarksideTests.swift
@@ -213,7 +213,9 @@ class SynchronizerDarksideTests: ZcashTestCase {
                 syncSessionID: uuids[0],
                 shieldedBalance: WalletBalance(verified: Zatoshi(100000), total: Zatoshi(200000)),
                 transparentBalance: .zero,
-                internalSyncStatus: .enhancing(EnhancementProgress(totalTransactions: 0, enhancedTransactions: 0, lastFoundTransaction: nil, range: 0...0, newlyMined: false)),
+                internalSyncStatus: .enhancing(
+                    EnhancementProgress(totalTransactions: 0, enhancedTransactions: 0, lastFoundTransaction: nil, range: 0...0, newlyMined: false)
+                ),
                 latestScannedHeight: 663189,
                 latestBlockHeight: 663189,
                 latestScannedTime: 1

--- a/Tests/DarksideTests/SynchronizerTests.swift
+++ b/Tests/DarksideTests/SynchronizerTests.swift
@@ -160,7 +160,7 @@ final class SynchronizerTests: ZcashTestCase {
         /*
          Check that wipe cleared everything that is expected
          */
-        await checkThatWipeWorked()
+        try await checkThatWipeWorked()
     }
 
     func testWipeCalledWhileSyncRuns() async throws {
@@ -217,10 +217,10 @@ final class SynchronizerTests: ZcashTestCase {
         /*
          Check that wipe cleared everything that is expected
          */
-        await checkThatWipeWorked()
+        try await checkThatWipeWorked()
     }
 
-    private func checkThatWipeWorked() async {
+    private func checkThatWipeWorked() async throws {
         let storage = await self.coordinator.synchronizer.blockProcessor.storage as! FSCompactBlockRepository
         let fm = FileManager.default
         print(coordinator.synchronizer.initializer.dataDbURL.path)
@@ -229,15 +229,11 @@ final class SynchronizerTests: ZcashTestCase {
         XCTAssertTrue(fm.fileExists(atPath: storage.blocksDirectory.path), "FS Cache directory should exist")
         XCTAssertEqual(try fm.contentsOfDirectory(atPath: storage.blocksDirectory.path), [], "FS Cache directory should be empty")
 
-        let internalSyncProgress = InternalSyncProgress(
-            alias: .default,
-            storage: UserDefaults.standard,
-            logger: logger
-        )
+        let internalSyncProgress = coordinator.synchronizer.internalSyncProgress
 
-        let latestDownloadedBlockHeight = await internalSyncProgress.load(.latestDownloadedBlockHeight)
-        let latestEnhancedHeight = await internalSyncProgress.load(.latestEnhancedHeight)
-        let latestUTXOFetchedHeight = await internalSyncProgress.load(.latestUTXOFetchedHeight)
+        let latestDownloadedBlockHeight = try await internalSyncProgress.load(.latestDownloadedBlockHeight)
+        let latestEnhancedHeight = try await internalSyncProgress.load(.latestEnhancedHeight)
+        let latestUTXOFetchedHeight = try await internalSyncProgress.load(.latestUTXOFetchedHeight)
 
         XCTAssertEqual(latestDownloadedBlockHeight, 0, "internalSyncProgress latestDownloadedBlockHeight should be 0")
         XCTAssertEqual(latestEnhancedHeight, 0, "internalSyncProgress latestEnhancedHeight should be 0")

--- a/Tests/DarksideTests/TransactionEnhancementTests.swift
+++ b/Tests/DarksideTests/TransactionEnhancementTests.swift
@@ -20,7 +20,6 @@ class TransactionEnhancementTests: ZcashTestCase {
     let branchID = "2bb40e60"
     let chainName = "main"
 
-    var testTempDirectory: URL!
     let testFileManager = FileManager()
 
     var initializer: Initializer!
@@ -40,15 +39,7 @@ class TransactionEnhancementTests: ZcashTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        testTempDirectory = Environment.uniqueTestTempDirectory
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
-
-        await InternalSyncProgress(
-            alias: .default,
-            storage: UserDefaults.standard,
-            logger: logger
-        ).rewind(to: 0)
-
+        
         logger = OSLogger(logLevel: .debug)
         
         syncStartedExpect = XCTestExpectation(description: "\(self.description) syncStartedExpect")
@@ -140,6 +131,7 @@ class TransactionEnhancementTests: ZcashTestCase {
             urls: Initializer.URLs(
                 fsBlockDbRoot: testTempDirectory,
                 dataDbURL: pathProvider.dataDbURL,
+                generalStorageURL: testGeneralStorageDirectory,
                 spendParamsURL: pathProvider.spendParamsURL,
                 outputParamsURL: pathProvider.outputParamsURL
             ),

--- a/Tests/NetworkTests/BlockScanTests.swift
+++ b/Tests/NetworkTests/BlockScanTests.swift
@@ -30,7 +30,6 @@ class BlockScanTests: ZcashTestCase {
     
     var network = ZcashNetworkBuilder.network(for: .testnet)
     var blockRepository: BlockRepository!
-    var testTempDirectory: URL!
 
     let testFileManager = FileManager()
 
@@ -40,9 +39,6 @@ class BlockScanTests: ZcashTestCase {
         dataDbURL = try! __dataDbURL()
         spendParamsURL = try! __spendParamsURL()
         outputParamsURL = try! __outputParamsURL()
-        testTempDirectory = Environment.uniqueTestTempDirectory
-
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
 
         rustBackend = ZcashRustBackend.makeForTests(
             dbData: dataDbURL,
@@ -57,6 +53,7 @@ class BlockScanTests: ZcashTestCase {
             urls: Initializer.URLs(
                 fsBlockDbRoot: testTempDirectory,
                 dataDbURL: dataDbURL,
+                generalStorageURL: testGeneralStorageDirectory,
                 spendParamsURL: spendParamsURL,
                 outputParamsURL: outputParamsURL
             ),
@@ -80,7 +77,6 @@ class BlockScanTests: ZcashTestCase {
         try? testFileManager.removeItem(at: dataDbURL)
         try? testFileManager.removeItem(at: spendParamsURL)
         try? testFileManager.removeItem(at: outputParamsURL)
-        try? testFileManager.removeItem(at: testTempDirectory)
         cancelables = []
         blockRepository = nil
         testTempDirectory = nil

--- a/Tests/NetworkTests/BlockStreamingTest.swift
+++ b/Tests/NetworkTests/BlockStreamingTest.swift
@@ -12,14 +12,11 @@ import XCTest
 class BlockStreamingTest: ZcashTestCase {
     let testFileManager = FileManager()
     var rustBackend: ZcashRustBackendWelding!
-    var testTempDirectory: URL!
 
     override func setUp() async throws {
         try await super.setUp()
         logger = OSLogger(logLevel: .debug)
-        testTempDirectory = Environment.uniqueTestTempDirectory
 
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
         rustBackend = ZcashRustBackend.makeForTests(fsBlockDbRoot: testTempDirectory, networkType: .testnet)
         logger = OSLogger(logLevel: .debug)
 
@@ -28,6 +25,7 @@ class BlockStreamingTest: ZcashTestCase {
             urls: Initializer.URLs(
                 fsBlockDbRoot: testTempDirectory,
                 dataDbURL: try! __dataDbURL(),
+                generalStorageURL: testGeneralStorageDirectory,
                 spendParamsURL: try! __spendParamsURL(),
                 outputParamsURL: try! __outputParamsURL()
             ),
@@ -45,7 +43,6 @@ class BlockStreamingTest: ZcashTestCase {
         try super.tearDownWithError()
         rustBackend = nil
         try? FileManager.default.removeItem(at: __dataDbURL())
-        try? testFileManager.removeItem(at: testTempDirectory)
         testTempDirectory = nil
     }
 

--- a/Tests/NetworkTests/DownloadTests.swift
+++ b/Tests/NetworkTests/DownloadTests.swift
@@ -14,21 +14,16 @@ import SQLite
 class DownloadTests: ZcashTestCase {
     let testFileManager = FileManager()
     var network = ZcashNetworkBuilder.network(for: .testnet)
-    var testTempDirectory: URL!
 
     override func setUp() async throws {
         try await super.setUp()
-        testTempDirectory = Environment.uniqueTestTempDirectory
-        try? FileManager.default.removeItem(at: testTempDirectory)
-        await InternalSyncProgress(alias: .default, storage: UserDefaults.standard, logger: logger).rewind(to: 0)
 
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
-        
         Dependencies.setup(
             in: mockContainer,
             urls: Initializer.URLs(
                 fsBlockDbRoot: testTempDirectory,
                 dataDbURL: try! __dataDbURL(),
+                generalStorageURL: testGeneralStorageDirectory,
                 spendParamsURL: try! __spendParamsURL(),
                 outputParamsURL: try! __outputParamsURL()
             ),
@@ -43,8 +38,6 @@ class DownloadTests: ZcashTestCase {
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try? testFileManager.removeItem(at: testTempDirectory)
-        testTempDirectory = nil
     }
 
     func testSingleDownload() async throws {

--- a/Tests/OfflineTests/CompactBlockProcessorOfflineTests.swift
+++ b/Tests/OfflineTests/CompactBlockProcessorOfflineTests.swift
@@ -11,17 +11,16 @@ import XCTest
 
 class CompactBlockProcessorOfflineTests: ZcashTestCase {
     let testFileManager = FileManager()
-    var testTempDirectory: URL!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        testTempDirectory = Environment.uniqueTestTempDirectory
 
         Dependencies.setup(
             in: mockContainer,
             urls: Initializer.URLs(
                 fsBlockDbRoot: testTempDirectory,
                 dataDbURL: try! __dataDbURL(),
+                generalStorageURL: testGeneralStorageDirectory,
                 spendParamsURL: try! __spendParamsURL(),
                 outputParamsURL: try! __outputParamsURL()
             ),
@@ -30,13 +29,10 @@ class CompactBlockProcessorOfflineTests: ZcashTestCase {
             endpoint: LightWalletEndpointBuilder.default,
             loggingPolicy: .default(.debug)
         )
-
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try FileManager.default.removeItem(at: testTempDirectory)
     }
 
     func testComputeProcessingRangeForSingleLoop() async throws {

--- a/Tests/OfflineTests/CompactBlockRepositoryTests.swift
+++ b/Tests/OfflineTests/CompactBlockRepositoryTests.swift
@@ -11,24 +11,19 @@ import Foundation
 @testable import ZcashLightClientKit
 import XCTest
 
-class CompactBlockRepositoryTests: XCTestCase {
+class CompactBlockRepositoryTests: ZcashTestCase {
     let network = ZcashNetworkBuilder.network(for: .testnet)
     let testFileManager = FileManager()
     var rustBackend: ZcashRustBackendWelding!
-    var testTempDirectory: URL!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        testTempDirectory = Environment.uniqueTestTempDirectory
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
         rustBackend = ZcashRustBackend.makeForTests(fsBlockDbRoot: testTempDirectory, networkType: .testnet)
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try? testFileManager.removeItem(at: testTempDirectory)
         rustBackend = nil
-        testTempDirectory = nil
     }
 
     func testEmptyStorage() async throws {

--- a/Tests/OfflineTests/FsBlockStorageTests.swift
+++ b/Tests/OfflineTests/FsBlockStorageTests.swift
@@ -10,18 +10,15 @@ import XCTest
 
 var logger = OSLogger(logLevel: .debug)
 
-final class FsBlockStorageTests: XCTestCase {
+final class FsBlockStorageTests: ZcashTestCase {
     let testFileManager = FileManager()
     var fsBlockDb: URL!
     var rustBackend: ZcashRustBackendWelding!
-    var testTempDirectory: URL!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        testTempDirectory = Environment.uniqueTestTempDirectory
         // Put setup code here. This method is called before the invocation of each test method in the class.
         self.fsBlockDb = testTempDirectory.appendingPathComponent("FsBlockDb-\(Int.random(in: 0 ... .max))")
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
         try self.testFileManager.createDirectory(at: self.fsBlockDb, withIntermediateDirectories: false)
 
         rustBackend = ZcashRustBackend.makeForTests(fsBlockDbRoot: testTempDirectory, networkType: .testnet)
@@ -29,9 +26,7 @@ final class FsBlockStorageTests: XCTestCase {
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
-        try? testFileManager.removeItem(at: testTempDirectory)
         rustBackend = nil
-        testTempDirectory = nil
     }
 
     func testLatestHeightEmptyCache() async throws {

--- a/Tests/OfflineTests/InitializerOfflineTests.swift
+++ b/Tests/OfflineTests/InitializerOfflineTests.swift
@@ -20,6 +20,7 @@ class InitializerOfflineTests: XCTestCase {
     private func makeInitializer(
         fsBlockDbRoot: URL,
         dataDbURL: URL,
+        generalStorageURL: URL,
         spendParamsURL: URL,
         outputParamsURL: URL,
         alias: ZcashSynchronizerAlias
@@ -27,6 +28,7 @@ class InitializerOfflineTests: XCTestCase {
         return Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: fsBlockDbRoot,
+            generalStorageURL: generalStorageURL,
             dataDbURL: dataDbURL,
             endpoint: LightWalletEndpointBuilder.default,
             network: ZcashNetworkBuilder.network(for: .testnet),
@@ -52,6 +54,7 @@ class InitializerOfflineTests: XCTestCase {
     private func genericTestForURLsParsingFailures(
         fsBlockDbRoot: URL,
         dataDbURL: URL,
+        generalStorageURL: URL,
         spendParamsURL: URL,
         outputParamsURL: URL,
         alias: ZcashSynchronizerAlias,
@@ -60,6 +63,7 @@ class InitializerOfflineTests: XCTestCase {
         let initializer = makeInitializer(
             fsBlockDbRoot: fsBlockDbRoot,
             dataDbURL: dataDbURL,
+            generalStorageURL: generalStorageURL,
             spendParamsURL: spendParamsURL,
             outputParamsURL: outputParamsURL,
             alias: alias
@@ -81,6 +85,7 @@ class InitializerOfflineTests: XCTestCase {
         let initializer = makeInitializer(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: .default
@@ -97,6 +102,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: invalidPathURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: .default
@@ -107,6 +113,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: invalidPathURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: .default
@@ -117,6 +124,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: invalidPathURL,
             outputParamsURL: validFileURL,
             alias: .default
@@ -127,8 +135,20 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: invalidPathURL,
+            alias: .default
+        )
+    }
+
+    func test__defaultAlias__invalidGeneralStorageURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            generalStorageURL: invalidPathURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
             alias: .default
         )
     }
@@ -138,6 +158,7 @@ class InitializerOfflineTests: XCTestCase {
         let initializer = makeInitializer(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: alias
@@ -154,6 +175,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: invalidPathURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: .custom("alias")
@@ -164,6 +186,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: invalidPathURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: validFileURL,
             alias: .custom("alias")
@@ -174,6 +197,7 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: invalidPathURL,
             outputParamsURL: validFileURL,
             alias: .custom("alias")
@@ -184,8 +208,20 @@ class InitializerOfflineTests: XCTestCase {
         genericTestForURLsParsingFailures(
             fsBlockDbRoot: validDirectoryURL,
             dataDbURL: validFileURL,
+            generalStorageURL: validDirectoryURL,
             spendParamsURL: validFileURL,
             outputParamsURL: invalidPathURL,
+            alias: .custom("alias")
+        )
+    }
+
+    func test__customAlias__invalidGeneralStorageURL__errorIsGenerated() {
+        genericTestForURLsParsingFailures(
+            fsBlockDbRoot: validDirectoryURL,
+            dataDbURL: validFileURL,
+            generalStorageURL: invalidPathURL,
+            spendParamsURL: validFileURL,
+            outputParamsURL: validFileURL,
             alias: .custom("alias")
         )
     }

--- a/Tests/OfflineTests/SynchronizerOfflineTests.swift
+++ b/Tests/OfflineTests/SynchronizerOfflineTests.swift
@@ -288,6 +288,7 @@ class SynchronizerOfflineTests: ZcashTestCase {
         let initializer = Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: validDirectoryURL,
+            generalStorageURL: validDirectoryURL,
             dataDbURL: invalidPathURL,
             endpoint: LightWalletEndpointBuilder.default,
             network: ZcashNetworkBuilder.network(for: .testnet),
@@ -328,6 +329,7 @@ class SynchronizerOfflineTests: ZcashTestCase {
         let initializer = Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: validDirectoryURL,
+            generalStorageURL: validDirectoryURL,
             dataDbURL: invalidPathURL,
             endpoint: LightWalletEndpointBuilder.default,
             network: ZcashNetworkBuilder.network(for: .testnet),

--- a/Tests/OfflineTests/WalletTests.swift
+++ b/Tests/OfflineTests/WalletTests.swift
@@ -11,9 +11,8 @@ import XCTest
 @testable import TestUtils
 @testable import ZcashLightClientKit
 
-class WalletTests: XCTestCase {
+class WalletTests: ZcashTestCase {
     let testFileManager = FileManager()
-    var testTempDirectory: URL!
     var dbData: URL! = nil
     var paramDestination: URL! = nil
     var network = ZcashNetworkBuilder.network(for: .testnet)
@@ -21,9 +20,7 @@ class WalletTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        testTempDirectory = Environment.uniqueTestTempDirectory
         dbData = try __dataDbURL()
-        try self.testFileManager.createDirectory(at: testTempDirectory, withIntermediateDirectories: false)
         paramDestination = try __documentsDirectory().appendingPathComponent("parameters")
     }
     
@@ -32,7 +29,6 @@ class WalletTests: XCTestCase {
         if testFileManager.fileExists(atPath: dbData.absoluteString) {
             try testFileManager.trashItem(at: dbData, resultingItemURL: nil)
         }
-        try? self.testFileManager.removeItem(at: testTempDirectory)
     }
     
     func testWalletInitialization() async throws {
@@ -43,6 +39,7 @@ class WalletTests: XCTestCase {
         let wallet = Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: testTempDirectory,
+            generalStorageURL: testGeneralStorageDirectory,
             dataDbURL: try __dataDbURL(),
             endpoint: LightWalletEndpointBuilder.default,
             network: network,

--- a/Tests/TestUtils/InternalSyncProgressMemoryStorage.swift
+++ b/Tests/TestUtils/InternalSyncProgressMemoryStorage.swift
@@ -12,20 +12,22 @@ class InternalSyncProgressMemoryStorage: InternalSyncProgressStorage {
     private var boolStorage: [String: Bool] = [:]
     private var storage: [String: Int] = [:]
 
-    func bool(forKey defaultName: String) -> Bool {
-        return boolStorage[defaultName, default: false]
+    func initialize() async throws { }
+
+    func bool(for key: String) async throws -> Bool {
+        return boolStorage[key, default: false]
     }
 
-    func integer(forKey defaultName: String) -> Int {
-        return storage[defaultName, default: 0]
+    func integer(for key: String) async throws -> Int {
+        return storage[key, default: 0]
     }
 
-    func set(_ value: Int, forKey defaultName: String) {
-        storage[defaultName] = value
+    func set(_ value: Int, for key: String) async throws {
+        storage[key] = value
     }
 
-    func set(_ value: Bool, forKey defaultName: String) {
-        boolStorage[defaultName] = value
+    func set(_ value: Bool, for key: String) async throws {
+        boolStorage[key] = value
     }
 
     func synchronize() -> Bool { true }

--- a/Tests/TestUtils/Tests+Utils.swift
+++ b/Tests/TestUtils/Tests+Utils.swift
@@ -33,6 +33,11 @@ enum Environment {
         URL(fileURLWithPath: NSString(string: NSTemporaryDirectory())
             .appendingPathComponent("tmp-\(Int.random(in: 0 ... .max))"))
     }
+
+    static var uniqueGeneralStorageDirectory: URL {
+        URL(fileURLWithPath: NSString(string: NSTemporaryDirectory())
+            .appendingPathComponent("gens-\(Int.random(in: 0 ... .max))"))
+    }
 }
 
 public enum Constants {

--- a/Tests/TestUtils/TestsData.swift
+++ b/Tests/TestUtils/TestsData.swift
@@ -15,6 +15,7 @@ class TestsData {
         Initializer(
             cacheDbURL: nil,
             fsBlockDbRoot: URL(fileURLWithPath: "/"),
+            generalStorageURL: URL(fileURLWithPath: "/"),
             dataDbURL: URL(fileURLWithPath: "/"),
             endpoint: LightWalletEndpointBuilder.default,
             network: ZcashNetworkBuilder.network(for: networkType),

--- a/Tests/TestUtils/ZcashTestCase.swift
+++ b/Tests/TestUtils/ZcashTestCase.swift
@@ -11,6 +11,10 @@ import XCTest
 
 class ZcashTestCase: XCTestCase {
     var mockContainer: DIContainer!
+    var testTempDirectory: URL!
+    var testGeneralStorageDirectory: URL!
+
+    // MARK: - DI
 
     private func createMockContainer() {
         guard mockContainer == nil else { return }
@@ -22,33 +26,84 @@ class ZcashTestCase: XCTestCase {
         mockContainer = nil
     }
 
+    // MARK: - Paths
+
+    private func create(path: URL!) throws {
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+    }
+
+    private func delete(path: URL!) throws {
+        if path != nil && FileManager.default.fileExists(atPath: path.path) {
+            try FileManager.default.removeItem(at: path)
+        }
+    }
+
+    private func createPaths() throws {
+        if testTempDirectory == nil {
+            testTempDirectory = Environment.uniqueTestTempDirectory
+            try delete(path: testTempDirectory)
+            try create(path: testTempDirectory)
+        }
+
+        if testGeneralStorageDirectory == nil {
+            testGeneralStorageDirectory = Environment.uniqueGeneralStorageDirectory
+            try delete(path: testGeneralStorageDirectory)
+            try create(path: testGeneralStorageDirectory)
+        }
+    }
+
+    private func deletePaths() throws {
+        try delete(path: testTempDirectory)
+        testTempDirectory = nil
+        try delete(path: testGeneralStorageDirectory)
+        testGeneralStorageDirectory = nil
+    }
+
+    // MARK: - InternalSyncProgress
+
+    func resetDefaultInternalSyncProgress(to height: BlockHeight = 0) async throws {
+        let storage = InternalSyncProgressDiskStorage(storageURL: testGeneralStorageDirectory, logger: logger)
+        let internalSyncProgress = InternalSyncProgress(alias: .default, storage: storage, logger: logger)
+        try await internalSyncProgress.initialize()
+        try await internalSyncProgress.rewind(to: 0)
+    }
+
+    // MARK: - XCTestCase
+
     override func setUp() async throws {
         try await super.setUp()
         createMockContainer()
+        try createPaths()
+        try await resetDefaultInternalSyncProgress()
     }
 
     override func setUp() {
         super.setUp()
         createMockContainer()
+        try? createPaths()
     }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         createMockContainer()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        destroyMockContainer()
+        try createPaths()
     }
 
     override func tearDown() async throws {
         try await super.tearDown()
         destroyMockContainer()
+        try deletePaths()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        destroyMockContainer()
+        try? deletePaths()
     }
 
     override func tearDownWithError() throws {
         try super.tearDownWithError()
         destroyMockContainer()
+        try deletePaths()
     }
 }


### PR DESCRIPTION
Closes #1111

- `InternalSyncProgress` has now new disk storage implementation: `InternalSyncProgressDiskStorage`.
- When then `UserDefaults` was used as disk storage there were no IO errors to handle. But now the code in `InternalSyncProgressDiskStorage` writes to files and reads from files. So there are errors to handle. Because of this protocol `InternalSyncProgressStorage` changed a bit and API of `InternalSyncProgress` changed a bit. Now all the functions throws.
- It is possible to make progress storage IO errors silent but I think that storing of the progress is very essential to the sync process. So I think that when progress storage fails then the sync process should fail.
- `Initializer` has new parameter `generalStorageURL`. It is directory where `InternalSyncProgressDiskStorage` stores progress files. In future this can be used for storing any data the SDK wants.

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [x] Automated tests: Did you add appropriate automated tests for any code changes?
- [ ] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [x] Run the app: Did you run the app and try the changes? 
- [ ] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [x] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [ ] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.