### PR TITLE
[#1181] Correct computation of progress for Spend before Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ be able to write to this location after it creates this directory. It is suggest
 a subdirectory of the `Documents` directory. If this information is stored in `Documents` then the
 system itself won't remove these data.
 
+### Removed
+
+### [#1181] Correct computation of progress for Spend before Sync
+`latestScannedHeight` and `latestScannedTime` have been removed from `SynchronizerState`. With multiple algorithms
+of syncing the amount of data provided is reduced so it's consistent. Spend before Sync is done in non-linear order
+so both Height and Time don't make sense anymore. 
+
 # 0.22.0-beta
 
 ## Checkpoints

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/DemoAppConfig.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/DemoAppConfig.swift
@@ -18,7 +18,7 @@ enum DemoAppConfig {
         let seed: [UInt8]
     }
 
-    static let host = ZcashSDK.isMainnet ? "mainnet.lightwalletd.com" : "testnet.lightwalletd.com"
+    static let host = ZcashSDK.isMainnet ? "mainnet.lightwalletd.com" : "lightwalletd.testnet.electriccoin.co"
     static let port: Int = 9067
 
 //    static let defaultBirthdayHeight: BlockHeight = ZcashSDK.isMainnet ? 935000 : 1386000
@@ -30,7 +30,7 @@ enum DemoAppConfig {
     static let defaultSeed = try! Mnemonic.deterministicSeedBytes(from: """
     kitchen renew wide common vague fold vacuum tilt amazing pear square gossip jewel month tree shock scan alpha just spot fluid toilet view dinner
     """)
-    
+
     static let otherSynchronizers: [SynchronizerInitData] = [
         SynchronizerInitData(
             alias: .custom("alt-sync-1"),

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksListViewController.swift
@@ -112,7 +112,6 @@ class SyncBlocksListViewController: UIViewController {
             outputParamsURL: try! outputParamsURLHelper(),
             saplingParamsSourceURL: SaplingParamsSourceURL.default,
             alias: data.alias,
-            syncAlgorithm: .spendBeforeSync,
             loggingPolicy: .default(.debug),
             enableBackendTracing: true
         )

--- a/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
+++ b/Example/ZcashLightClientSample/ZcashLightClientSample/Sync Blocks/SyncBlocksViewController.swift
@@ -84,10 +84,7 @@ class SyncBlocksViewController: UIViewController {
 
             progressBar.progress = progress
             progressLabel.text = "\(floor(progress * 1000) / 10)%"
-            let syncedDate = dateFormatter.string(from: Date(timeIntervalSince1970: state.latestScannedTime))
             let progressText = """
-            synced date         \(syncedDate)
-            synced block        \(state.latestScannedHeight)
             latest block height \(state.latestBlockHeight)
             """
             progressDataLabel.text = progressText

--- a/Sources/ZcashLightClientKit/Block/Actions/Action.swift
+++ b/Sources/ZcashLightClientKit/Block/Actions/Action.swift
@@ -14,7 +14,10 @@ actor ActionContext {
     let preferredSyncAlgorithm: SyncAlgorithm
     var supportedSyncAlgorithm: SyncAlgorithm?
     var requestedRewindHeight: BlockHeight?
+    /// Represents the overall range of blocks that will be synced, `SyncAlgorithm` doesn't matter.
     var totalProgressRange: CompactBlockRange = 0...0
+    /// Amount of blocks that have been processed so far
+    var processedHeight: BlockHeight = 0
     var lastScannedHeight: BlockHeight?
     var lastDownloadedHeight: BlockHeight?
     var lastEnhancedHeight: BlockHeight?
@@ -30,7 +33,11 @@ actor ActionContext {
         self.state = state
     }
     func update(syncControlData: SyncControlData) async { self.syncControlData = syncControlData }
-    func update(totalProgressRange: CompactBlockRange) async { self.totalProgressRange = totalProgressRange }
+    func update(totalProgressRange: CompactBlockRange) async {
+        self.processedHeight = totalProgressRange.lowerBound
+        self.totalProgressRange = totalProgressRange
+    }
+    func update(processedHeight: BlockHeight) async { self.processedHeight = processedHeight }
     func update(lastScannedHeight: BlockHeight) async { self.lastScannedHeight = lastScannedHeight }
     func update(lastDownloadedHeight: BlockHeight) async { self.lastDownloadedHeight = lastDownloadedHeight }
     func update(lastEnhancedHeight: BlockHeight?) async { self.lastEnhancedHeight = lastEnhancedHeight }

--- a/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
+++ b/Sources/ZcashLightClientKit/Block/CompactBlockProcessor.swift
@@ -521,7 +521,7 @@ extension CompactBlockProcessor {
                 // Execute action.
                 context = try await action.run(with: context) { [weak self] event in
                     await self?.send(event: event)
-                    if let progressChanged = await self?.compactBlockProgress.event(event), progressChanged {
+                    if let progressChanged = await self?.compactBlockProgress.hasProgressUpdated(event), progressChanged {
                         if let progress = await self?.compactBlockProgress.progress {
                             await self?.send(event: .progressUpdated(progress))
                         }

--- a/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
+++ b/Sources/ZcashLightClientKit/Block/Scan/BlockScanner.swift
@@ -17,7 +17,7 @@ protocol BlockScanner {
     func scanBlocks(
         at range: CompactBlockRange,
         totalProgressRange: CompactBlockRange,
-        didScan: @escaping (BlockHeight) async -> Void
+        didScan: @escaping (BlockHeight, UInt32) async -> Void
     ) async throws -> BlockHeight
 }
 
@@ -35,7 +35,7 @@ extension BlockScannerImpl: BlockScanner {
     func scanBlocks(
         at range: CompactBlockRange,
         totalProgressRange: CompactBlockRange,
-        didScan: @escaping (BlockHeight) async -> Void
+        didScan: @escaping (BlockHeight, UInt32) async -> Void
     ) async throws -> BlockHeight {
         logger.debug("Going to scan blocks in range: \(range)")
         try Task.checkCancellation()
@@ -69,7 +69,7 @@ extension BlockScannerImpl: BlockScanner {
             
             scannedNewBlocks = previousScannedHeight != lastScannedHeight
             if scannedNewBlocks {
-                await didScan(lastScannedHeight)
+                await didScan(lastScannedHeight, batchSize)
 
                 let progress = BlockProgress(
                     startHeight: totalProgressRange.lowerBound,

--- a/Sources/ZcashLightClientKit/Block/Utils/CompactBlockProgress.swift
+++ b/Sources/ZcashLightClientKit/Block/Utils/CompactBlockProgress.swift
@@ -19,7 +19,7 @@ final actor CompactBlockProgress {
             switch self {
             case .enhance: return 0.08
             case .fetch: return 0.02
-            case .scan: return 0.9
+            case .scan: return 1.0
             }
         }
     }
@@ -35,18 +35,13 @@ final actor CompactBlockProgress {
         return overallProgress
     }
     
-    func event(_ event: CompactBlockProcessor.Event) -> Bool {
+    func hasProgressUpdated(_ event: CompactBlockProcessor.Event) -> Bool {
         guard case .progressPartialUpdate(let update) = event else {
             return false
         }
         
-        switch update {
-        case .syncing(let progress):
+        if case let .syncing(progress) = update {
             actionProgresses[.scan] = progress.progress
-        case .enhance(let progress):
-            actionProgresses[.enhance] = progress.progress
-        case .fetch(let progress):
-            actionProgresses[.fetch] = progress
         }
         
         return true

--- a/Sources/ZcashLightClientKit/Synchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer.swift
@@ -42,13 +42,8 @@ public struct SynchronizerState: Equatable {
     /// status of the whole sync process
     var internalSyncStatus: InternalSyncStatus
     public var syncStatus: SyncStatus
-    /// height of the latest scanned block known to this synchronizer.
-    public var latestScannedHeight: BlockHeight
     /// height of the latest block on the blockchain known to this synchronizer.
     public var latestBlockHeight: BlockHeight
-    /// timestamp of the latest scanned block on the blockchain known to this synchronizer.
-    /// The anchor point is timeIntervalSince1970
-    public var latestScannedTime: TimeInterval
 
     /// Represents a synchronizer that has made zero progress hasn't done a sync attempt
     public static var zero: SynchronizerState {
@@ -76,9 +71,7 @@ public struct SynchronizerState: Equatable {
         self.shieldedBalance = shieldedBalance
         self.transparentBalance = transparentBalance
         self.internalSyncStatus = internalSyncStatus
-        self.latestScannedHeight = latestScannedHeight
         self.latestBlockHeight = latestBlockHeight
-        self.latestScannedTime = latestScannedTime
         self.syncStatus = internalSyncStatus.mapToSyncStatus()
     }
 }

--- a/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
+++ b/Sources/ZcashLightClientKit/Synchronizer/SDKSynchronizer.swift
@@ -369,7 +369,7 @@ public class SDKSynchronizer: Synchronizer {
     }
 
     public func allPendingTransactions() async throws -> [ZcashTransaction.Overview] {
-        let latestScannedHeight = self.latestState.latestScannedHeight
+        let latestScannedHeight = try await transactionRepository.lastScannedHeight()
         
         return try await transactionRepository.findPendingTransactions(latestHeight: latestScannedHeight, offset: 0, limit: .max)
     }

--- a/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/TestUtils/Sourcery/GeneratedMocks/AutoMockable.generated.swift
@@ -361,11 +361,11 @@ class BlockScannerMock: BlockScanner {
     var scanBlocksAtTotalProgressRangeDidScanCalled: Bool {
         return scanBlocksAtTotalProgressRangeDidScanCallsCount > 0
     }
-    var scanBlocksAtTotalProgressRangeDidScanReceivedArguments: (range: CompactBlockRange, totalProgressRange: CompactBlockRange, didScan: (BlockHeight) async -> Void)?
+    var scanBlocksAtTotalProgressRangeDidScanReceivedArguments: (range: CompactBlockRange, totalProgressRange: CompactBlockRange, didScan: (BlockHeight, UInt32) async -> Void)?
     var scanBlocksAtTotalProgressRangeDidScanReturnValue: BlockHeight!
-    var scanBlocksAtTotalProgressRangeDidScanClosure: ((CompactBlockRange, CompactBlockRange, @escaping (BlockHeight) async -> Void) async throws -> BlockHeight)?
+    var scanBlocksAtTotalProgressRangeDidScanClosure: ((CompactBlockRange, CompactBlockRange, @escaping (BlockHeight, UInt32) async -> Void) async throws -> BlockHeight)?
 
-    func scanBlocks(at range: CompactBlockRange, totalProgressRange: CompactBlockRange, didScan: @escaping (BlockHeight) async -> Void) async throws -> BlockHeight {
+    func scanBlocks(at range: CompactBlockRange, totalProgressRange: CompactBlockRange, didScan: @escaping (BlockHeight, UInt32) async -> Void) async throws -> BlockHeight {
         if let error = scanBlocksAtTotalProgressRangeDidScanThrowableError {
             throw error
         }


### PR DESCRIPTION
Closes #1181 

- the computation of progress changed, the total range is computed, that way it works for any kind of sync algorithm
- the progress depends on finished scan action, whenever it processes some blocks, it's counted up
- the final progress is a ratio between these new values

This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->
- [x] Self-review: Did you review your own code in GitHub's web interface? Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs.
- [ ] Automated tests: Did you add appropriate automated tests for any code changes?
- [x] Code coverage: Did you check the code coverage report for the automated tests?  While we are not looking for perfect coverage, the tool can point out potential cases that have been missed.
- [ ] Documentation: Did you update Docs as appropiate? (E.g [README.md](../blob/main/README.md), etc.)
- [ ] Run the app: Did you run the app and try the changes? 
- [x] Did you provide Screenshots of what the App looks like before and after your changes as part of the description of this PR? (only applicable to UI Changes)
- [ ] Rebase and squash: Did you pull in the latest changes from the main branch and squash your commits before assigning a reviewer? Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit.


# Reviewer

- [x] Checklist review: Did you go through the code with the [Code Review Guidelines](../blob/main/CODE_REVIEW_GUIDELINES.md) checklist?
- [ ] Ad hoc review: Did you perform an ad hoc review?  _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
- [ ] Automated tests: Did you review the automated tests?
- [ ] Manual tests: Did you review the manual tests?_You will find manual testing guidelines under our [manual testing section](../blob/mater/docs/testing/manual_testing)_
- [ ] How is Code Coverage affected by this PR? _We encourage you to compare coverage befor and after your changes and when possible, leave it in a better place. [Learn More...](../blob/master/docs/testing/local_coverage.md)_
- [ ] Documentation: Did you review Docs, [README.md](../blob/master/README.md), [LICENSE.md](../blob/master/LICENSE.md), and [Architecture.md](../blob/master/docs/Architecture.md) as appropriate?
- [ ] Run the app: Did you run the app and try the changes? While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data.